### PR TITLE
Add backend: OpenAPI contract, Prisma schema, seed data, and package files

### DIFF
--- a/Worksie/backend/docs/openapi.yaml
+++ b/Worksie/backend/docs/openapi.yaml
@@ -1,0 +1,1558 @@
+openapi: 3.1.0
+info:
+  title: Worksie MVP API
+  version: 0.1.0
+  summary: Contract for milestone-based field operations, QA approval, progress invoicing, and contractor payouts.
+  description: |
+    This API contract maps the Worksie v1.0 product spec to backend endpoints for the MVP phases:
+    foundation data, job templates, milestone submissions, QA review, earned-value invoicing, and payout summaries.
+servers:
+  - url: http://localhost:4000
+    description: Local development
+security:
+  - bearerAuth: []
+tags:
+  - name: Auth
+  - name: Organizations
+  - name: Master Data
+  - name: Templates
+  - name: Jobs
+  - name: Field Submissions
+  - name: QA
+  - name: Invoices
+  - name: Payouts
+  - name: Deductions
+  - name: Disputes
+  - name: Batches
+paths:
+  /auth/login:
+    post:
+      tags: [Auth]
+      summary: Start an authenticated session.
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginRequest'
+      responses:
+        '200':
+          description: Authenticated user and bearer token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthSession'
+  /auth/logout:
+    post:
+      tags: [Auth]
+      summary: End the current authenticated session.
+      responses:
+        '204':
+          description: Logged out.
+  /auth/me:
+    get:
+      tags: [Auth]
+      summary: Return the current user profile and role.
+      responses:
+        '200':
+          description: Current user.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+  /orgs:
+    post:
+      tags: [Organizations]
+      summary: Create an organization.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateOrganizationRequest'
+      responses:
+        '201':
+          description: Created organization.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Organization'
+  /orgs/{orgId}/users:
+    get:
+      tags: [Organizations]
+      summary: List organization users.
+      parameters:
+        - $ref: '#/components/parameters/OrgId'
+      responses:
+        '200':
+          description: Organization users.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'
+    post:
+      tags: [Organizations]
+      summary: Invite or create an organization user.
+      parameters:
+        - $ref: '#/components/parameters/OrgId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateUserRequest'
+      responses:
+        '201':
+          description: Created user.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+  /orgs/{orgId}/users/{userId}/role:
+    patch:
+      tags: [Organizations]
+      summary: Update a user role.
+      parameters:
+        - $ref: '#/components/parameters/OrgId'
+        - $ref: '#/components/parameters/UserId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [role]
+              properties:
+                role:
+                  $ref: '#/components/schemas/UserRole'
+      responses:
+        '200':
+          description: Updated user.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+  /orgs/{orgId}/clients:
+    get:
+      tags: [Master Data]
+      summary: List clients.
+      parameters:
+        - $ref: '#/components/parameters/OrgId'
+      responses:
+        '200':
+          description: Clients.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Client'
+    post:
+      tags: [Master Data]
+      summary: Create a client.
+      parameters:
+        - $ref: '#/components/parameters/OrgId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateClientRequest'
+      responses:
+        '201':
+          description: Created client.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Client'
+  /orgs/{orgId}/sites:
+    get:
+      tags: [Master Data]
+      summary: List job sites.
+      parameters:
+        - $ref: '#/components/parameters/OrgId'
+      responses:
+        '200':
+          description: Sites.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Site'
+    post:
+      tags: [Master Data]
+      summary: Create a site.
+      parameters:
+        - $ref: '#/components/parameters/OrgId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateSiteRequest'
+      responses:
+        '201':
+          description: Created site.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Site'
+  /orgs/{orgId}/contractors:
+    get:
+      tags: [Master Data]
+      summary: List contractors.
+      parameters:
+        - $ref: '#/components/parameters/OrgId'
+      responses:
+        '200':
+          description: Contractors.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Contractor'
+    post:
+      tags: [Master Data]
+      summary: Create a contractor.
+      parameters:
+        - $ref: '#/components/parameters/OrgId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateContractorRequest'
+      responses:
+        '201':
+          description: Created contractor.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Contractor'
+  /orgs/{orgId}/templates:
+    get:
+      tags: [Templates]
+      summary: List job templates.
+      parameters:
+        - $ref: '#/components/parameters/OrgId'
+      responses:
+        '200':
+          description: Job templates.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/JobTemplate'
+    post:
+      tags: [Templates]
+      summary: Create a job template.
+      parameters:
+        - $ref: '#/components/parameters/OrgId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateJobTemplateRequest'
+      responses:
+        '201':
+          description: Created template.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobTemplate'
+  /templates/{templateId}:
+    get:
+      tags: [Templates]
+      summary: Fetch a job template with milestones.
+      parameters:
+        - $ref: '#/components/parameters/TemplateId'
+      responses:
+        '200':
+          description: Job template detail.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobTemplateDetail'
+  /templates/{templateId}/milestones:
+    post:
+      tags: [Templates]
+      summary: Add a milestone to a job template.
+      parameters:
+        - $ref: '#/components/parameters/TemplateId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateTemplateMilestoneRequest'
+      responses:
+        '201':
+          description: Created template milestone.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TemplateMilestone'
+  /templates/{templateId}/milestones/{milestoneId}:
+    patch:
+      tags: [Templates]
+      summary: Update a template milestone.
+      parameters:
+        - $ref: '#/components/parameters/TemplateId'
+        - $ref: '#/components/parameters/MilestoneId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateTemplateMilestoneRequest'
+      responses:
+        '200':
+          description: Updated template milestone.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TemplateMilestone'
+  /orgs/{orgId}/jobs:
+    get:
+      tags: [Jobs]
+      summary: List jobs.
+      parameters:
+        - $ref: '#/components/parameters/OrgId'
+      responses:
+        '200':
+          description: Jobs.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Job'
+    post:
+      tags: [Jobs]
+      summary: Create a job from a template and materialize its milestones.
+      parameters:
+        - $ref: '#/components/parameters/OrgId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateJobRequest'
+      responses:
+        '201':
+          description: Created job with generated milestones.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobDetail'
+  /jobs/{jobId}:
+    get:
+      tags: [Jobs]
+      summary: Fetch job detail.
+      parameters:
+        - $ref: '#/components/parameters/JobId'
+      responses:
+        '200':
+          description: Job detail.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobDetail'
+  /jobs/{jobId}/status:
+    patch:
+      tags: [Jobs]
+      summary: Update job status.
+      parameters:
+        - $ref: '#/components/parameters/JobId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [status]
+              properties:
+                status:
+                  $ref: '#/components/schemas/JobStatus'
+      responses:
+        '200':
+          description: Updated job.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Job'
+  /jobs/{jobId}/milestones:
+    get:
+      tags: [Jobs]
+      summary: List materialized milestones for a job.
+      parameters:
+        - $ref: '#/components/parameters/JobId'
+      responses:
+        '200':
+          description: Job milestones.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/JobMilestone'
+  /jobs/{jobId}/milestones/{milestoneId}:
+    patch:
+      tags: [Jobs]
+      summary: Update a job milestone.
+      parameters:
+        - $ref: '#/components/parameters/JobId'
+        - $ref: '#/components/parameters/MilestoneId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateJobMilestoneRequest'
+      responses:
+        '200':
+          description: Updated job milestone.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobMilestone'
+  /jobs/{jobId}/milestones/{milestoneId}/assignments:
+    post:
+      tags: [Jobs]
+      summary: Assign a contractor to a job milestone with a payout split.
+      parameters:
+        - $ref: '#/components/parameters/JobId'
+        - $ref: '#/components/parameters/MilestoneId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateMilestoneAssignmentRequest'
+      responses:
+        '201':
+          description: Created milestone assignment.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MilestoneAssignment'
+  /jobs/{jobId}/milestones/{milestoneId}/submissions:
+    post:
+      tags: [Field Submissions]
+      summary: Submit field proof for a milestone.
+      parameters:
+        - $ref: '#/components/parameters/JobId'
+        - $ref: '#/components/parameters/MilestoneId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateFieldSubmissionRequest'
+      responses:
+        '201':
+          description: Created field submission.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FieldSubmission'
+  /submissions/{submissionId}/media/presign:
+    post:
+      tags: [Field Submissions]
+      summary: Create a signed upload target for proof media.
+      parameters:
+        - $ref: '#/components/parameters/SubmissionId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateMediaPresignRequest'
+      responses:
+        '200':
+          description: Signed media upload details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MediaPresignResponse'
+  /submissions/{submissionId}/media/attach:
+    post:
+      tags: [Field Submissions]
+      summary: Attach uploaded proof media to a field submission.
+      parameters:
+        - $ref: '#/components/parameters/SubmissionId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AttachMediaRequest'
+      responses:
+        '201':
+          description: Attached media record.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubmissionMedia'
+  /jobs/{jobId}/submissions:
+    get:
+      tags: [Field Submissions]
+      summary: List field submissions for a job.
+      parameters:
+        - $ref: '#/components/parameters/JobId'
+      responses:
+        '200':
+          description: Field submissions.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/FieldSubmission'
+  /submissions/{submissionId}:
+    get:
+      tags: [Field Submissions]
+      summary: Fetch field submission detail.
+      parameters:
+        - $ref: '#/components/parameters/SubmissionId'
+      responses:
+        '200':
+          description: Field submission detail.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FieldSubmission'
+  /qa/queue:
+    get:
+      tags: [QA]
+      summary: List submissions and milestones pending QA review.
+      parameters:
+        - name: orgId
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: status
+          in: query
+          schema:
+            $ref: '#/components/schemas/MilestoneStatus'
+      responses:
+        '200':
+          description: QA queue rows.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/QAQueueItem'
+  /qa/reviews:
+    post:
+      tags: [QA]
+      summary: Create a QA review decision.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateQAReviewRequest'
+      responses:
+        '201':
+          description: Created QA review.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QAReview'
+  /qa/reviews/{reviewId}/approve:
+    post:
+      tags: [QA]
+      summary: Approve submitted milestone work and convert it to earned value.
+      parameters:
+        - $ref: '#/components/parameters/ReviewId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QACompletionRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/QAReviewResponse'
+  /qa/reviews/{reviewId}/reject:
+    post:
+      tags: [QA]
+      summary: Reject submitted milestone work.
+      parameters:
+        - $ref: '#/components/parameters/ReviewId'
+      responses:
+        '200':
+          $ref: '#/components/responses/QAReviewResponse'
+  /qa/reviews/{reviewId}/partial-billable:
+    post:
+      tags: [QA]
+      summary: Mark a milestone as partially completed and billable.
+      parameters:
+        - $ref: '#/components/parameters/ReviewId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QACompletionRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/QAReviewResponse'
+  /qa/reviews/{reviewId}/partial-non-billable:
+    post:
+      tags: [QA]
+      summary: Mark a partial milestone as not usable and not billable.
+      parameters:
+        - $ref: '#/components/parameters/ReviewId'
+      responses:
+        '200':
+          $ref: '#/components/responses/QAReviewResponse'
+  /qa/reviews/{reviewId}/request-proof:
+    post:
+      tags: [QA]
+      summary: Request more required proof from the contractor.
+      parameters:
+        - $ref: '#/components/parameters/ReviewId'
+      responses:
+        '200':
+          $ref: '#/components/responses/QAReviewResponse'
+  /qa/reviews/{reviewId}/reassign:
+    post:
+      tags: [QA]
+      summary: Reassign milestone ownership after a handoff or incomplete work.
+      parameters:
+        - $ref: '#/components/parameters/ReviewId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReassignMilestoneRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/QAReviewResponse'
+  /qa/reviews/{reviewId}/apply-deduction:
+    post:
+      tags: [QA]
+      summary: Apply a rework or quality deduction during QA review.
+      parameters:
+        - $ref: '#/components/parameters/ReviewId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateDeductionRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/QAReviewResponse'
+  /jobs/{jobId}/invoices/generate-progress:
+    post:
+      tags: [Invoices]
+      summary: Generate a progress invoice from approved earned milestone value.
+      parameters:
+        - $ref: '#/components/parameters/JobId'
+      responses:
+        '201':
+          description: Generated progress invoice.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Invoice'
+  /jobs/{jobId}/invoices/generate-full:
+    post:
+      tags: [Invoices]
+      summary: Generate a final full invoice when all required milestones are approved.
+      parameters:
+        - $ref: '#/components/parameters/JobId'
+      responses:
+        '201':
+          description: Generated full invoice.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Invoice'
+  /jobs/{jobId}/invoices:
+    get:
+      tags: [Invoices]
+      summary: List invoices for a job.
+      parameters:
+        - $ref: '#/components/parameters/JobId'
+      responses:
+        '200':
+          description: Job invoices.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Invoice'
+  /invoices/{invoiceId}:
+    get:
+      tags: [Invoices]
+      summary: Fetch invoice detail.
+      parameters:
+        - $ref: '#/components/parameters/InvoiceId'
+      responses:
+        '200':
+          description: Invoice detail.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Invoice'
+  /invoices/{invoiceId}/status:
+    patch:
+      tags: [Invoices]
+      summary: Update invoice status.
+      parameters:
+        - $ref: '#/components/parameters/InvoiceId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [status]
+              properties:
+                status:
+                  $ref: '#/components/schemas/InvoiceStatus'
+      responses:
+        '200':
+          description: Updated invoice.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Invoice'
+  /jobs/{jobId}/payouts/recalculate:
+    post:
+      tags: [Payouts]
+      summary: Recalculate contractor payouts from approved milestone attribution.
+      parameters:
+        - $ref: '#/components/parameters/JobId'
+      responses:
+        '200':
+          description: Recalculated payout summaries.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Payout'
+  /jobs/{jobId}/payouts:
+    get:
+      tags: [Payouts]
+      summary: List payouts for a job.
+      parameters:
+        - $ref: '#/components/parameters/JobId'
+      responses:
+        '200':
+          description: Job payouts.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Payout'
+  /contractors/{contractorId}/payouts:
+    get:
+      tags: [Payouts]
+      summary: List payouts for a contractor.
+      parameters:
+        - $ref: '#/components/parameters/ContractorId'
+      responses:
+        '200':
+          description: Contractor payouts.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Payout'
+  /jobs/{jobId}/deductions:
+    post:
+      tags: [Deductions]
+      summary: Create a deduction for rework, waste, failed QA, return trip, or admin adjustment.
+      parameters:
+        - $ref: '#/components/parameters/JobId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateDeductionRequest'
+      responses:
+        '201':
+          description: Created deduction.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Deduction'
+  /jobs/{jobId}/milestones/{milestoneId}/reassign:
+    post:
+      tags: [Jobs]
+      summary: Reassign a milestone and freeze previous contractor credit until admin validation.
+      parameters:
+        - $ref: '#/components/parameters/JobId'
+        - $ref: '#/components/parameters/MilestoneId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReassignMilestoneRequest'
+      responses:
+        '200':
+          description: Updated assignments.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MilestoneAssignment'
+  /jobs/{jobId}/disputes:
+    post:
+      tags: [Disputes]
+      summary: Open a dispute and lock only the affected milestone's invoice and payout impact.
+      parameters:
+        - $ref: '#/components/parameters/JobId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateDisputeRequest'
+      responses:
+        '201':
+          description: Created dispute.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Dispute'
+  /disputes/{disputeId}/resolve:
+    patch:
+      tags: [Disputes]
+      summary: Resolve a dispute with final earned-value or deduction adjustment.
+      parameters:
+        - $ref: '#/components/parameters/DisputeId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ResolveDisputeRequest'
+      responses:
+        '200':
+          description: Resolved dispute.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Dispute'
+  /disputes/{disputeId}/lock-impact:
+    post:
+      tags: [Disputes]
+      summary: Lock invoice and payout activity for the affected milestone.
+      parameters:
+        - $ref: '#/components/parameters/DisputeId'
+      responses:
+        '204':
+          description: Milestone financial impact locked.
+  /orgs/{orgId}/batches/generate-weekly:
+    post:
+      tags: [Batches]
+      summary: Generate a weekly billing and payout batch from approved earned values.
+      parameters:
+        - $ref: '#/components/parameters/OrgId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GenerateWeeklyBatchRequest'
+      responses:
+        '201':
+          description: Generated weekly batch.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Batch'
+  /orgs/{orgId}/batches:
+    get:
+      tags: [Batches]
+      summary: List weekly batches.
+      parameters:
+        - $ref: '#/components/parameters/OrgId'
+      responses:
+        '200':
+          description: Weekly batches.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Batch'
+  /batches/{batchId}:
+    get:
+      tags: [Batches]
+      summary: Fetch a weekly batch with payout rows.
+      parameters:
+        - $ref: '#/components/parameters/BatchId'
+      responses:
+        '200':
+          description: Weekly batch detail.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BatchDetail'
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  responses:
+    QAReviewResponse:
+      description: QA review result.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/QAReview'
+  parameters:
+    OrgId:
+      name: orgId
+      in: path
+      required: true
+      schema:
+        type: string
+    UserId:
+      name: userId
+      in: path
+      required: true
+      schema:
+        type: string
+    TemplateId:
+      name: templateId
+      in: path
+      required: true
+      schema:
+        type: string
+    JobId:
+      name: jobId
+      in: path
+      required: true
+      schema:
+        type: string
+    MilestoneId:
+      name: milestoneId
+      in: path
+      required: true
+      schema:
+        type: string
+    SubmissionId:
+      name: submissionId
+      in: path
+      required: true
+      schema:
+        type: string
+    ReviewId:
+      name: reviewId
+      in: path
+      required: true
+      schema:
+        type: string
+    InvoiceId:
+      name: invoiceId
+      in: path
+      required: true
+      schema:
+        type: string
+    ContractorId:
+      name: contractorId
+      in: path
+      required: true
+      schema:
+        type: string
+    DisputeId:
+      name: disputeId
+      in: path
+      required: true
+      schema:
+        type: string
+    BatchId:
+      name: batchId
+      in: path
+      required: true
+      schema:
+        type: string
+  schemas:
+    UserRole:
+      type: string
+      enum: [OWNER, ADMIN, DISPATCHER, QA_REVIEWER, CONTRACTOR, CLIENT_VIEWER]
+    JobStatus:
+      type: string
+      enum: [NOT_STARTED, SCHEDULED, IN_PROGRESS, PARTIALLY_COMPLETED_BILLABLE, PARTIALLY_COMPLETED_NON_BILLABLE, COMPLETED_PENDING_QA, COMPLETED_APPROVED, REWORK_REQUIRED, REASSIGNED, FAILED, DISPUTED, CLOSED]
+    MilestoneStatus:
+      type: string
+      enum: [NOT_STARTED, IN_PROGRESS, COMPLETED_PENDING_QA, COMPLETED_APPROVED, PARTIAL_BILLABLE, PARTIAL_NON_BILLABLE, REJECTED, REWORK_REQUIRED, REASSIGNED, DISPUTED]
+    InvoiceStatus:
+      type: string
+      enum: [NOT_INVOICED, PARTIAL_INVOICE_READY, INVOICE_READY, READY_FOR_REVIEW, APPROVED, SENT, PAID, HELD, DISPUTED, VOIDED]
+    InvoiceType:
+      type: string
+      enum: [FULL, PARTIAL, PROGRESS, REWORK_ADJUSTED, MULTI_CONTRACTOR, DISPUTED_HOLD, WEEKLY_BATCH, FINAL_CLOSEOUT]
+    PayoutStatus:
+      type: string
+      enum: [NOT_READY, PENDING_REVIEW, APPROVED, BATCHED, PAID, HELD, DEDUCTED, DISPUTED]
+    SubmissionType:
+      type: string
+      enum: [PROGRESS_UPDATE, COMPLETION, REWORK_UPDATE, BLOCKED_UPDATE]
+    QAAction:
+      type: string
+      enum: [APPROVE, REJECT, PARTIAL_BILLABLE, PARTIAL_NON_BILLABLE, REQUEST_MORE_PROOF, APPLY_DEDUCTION, REASSIGN, LOCK_INVOICE, ESCALATE_DISPUTE]
+    MediaType:
+      type: string
+      enum: [PHOTO_BEFORE, PHOTO_PROGRESS, PHOTO_COMPLETION, VOICE_NOTE, DOCUMENT, SIGNATURE]
+    Money:
+      type: string
+      pattern: '^\\d+(\\.\\d{1,2})?$'
+      examples: ['2500.00']
+    Organization:
+      type: object
+      required: [id, name]
+      properties:
+        id: { type: string }
+        name: { type: string }
+    CreateOrganizationRequest:
+      type: object
+      required: [name]
+      properties:
+        name: { type: string }
+    User:
+      type: object
+      required: [id, organizationId, email, fullName, role, isActive]
+      properties:
+        id: { type: string }
+        organizationId: { type: string }
+        email: { type: string, format: email }
+        fullName: { type: string }
+        role:
+          $ref: '#/components/schemas/UserRole'
+        isActive: { type: boolean }
+    LoginRequest:
+      type: object
+      required: [email, password]
+      properties:
+        email: { type: string, format: email }
+        password: { type: string, format: password }
+    AuthSession:
+      type: object
+      required: [token, user]
+      properties:
+        token: { type: string }
+        user:
+          $ref: '#/components/schemas/User'
+    CreateUserRequest:
+      type: object
+      required: [email, fullName, role]
+      properties:
+        email: { type: string, format: email }
+        fullName: { type: string }
+        role:
+          $ref: '#/components/schemas/UserRole'
+    Client:
+      type: object
+      required: [id, organizationId, name]
+      properties:
+        id: { type: string }
+        organizationId: { type: string }
+        name: { type: string }
+        externalRef: { type: string, nullable: true }
+    CreateClientRequest:
+      type: object
+      required: [name]
+      properties:
+        name: { type: string }
+        externalRef: { type: string }
+    Site:
+      type: object
+      required: [id, organizationId, clientId, name]
+      properties:
+        id: { type: string }
+        organizationId: { type: string }
+        clientId: { type: string }
+        name: { type: string }
+        address1: { type: string }
+        city: { type: string }
+        state: { type: string }
+        postalCode: { type: string }
+        country: { type: string }
+        lat: { type: number }
+        lng: { type: number }
+    CreateSiteRequest:
+      type: object
+      required: [clientId, name]
+      properties:
+        clientId: { type: string }
+        name: { type: string }
+        address1: { type: string }
+        city: { type: string }
+        state: { type: string }
+        postalCode: { type: string }
+        country: { type: string }
+        lat: { type: number }
+        lng: { type: number }
+    Contractor:
+      type: object
+      required: [id, organizationId, displayName, isActive]
+      properties:
+        id: { type: string }
+        organizationId: { type: string }
+        displayName: { type: string }
+        email: { type: string, format: email }
+        phone: { type: string }
+        isActive: { type: boolean }
+    CreateContractorRequest:
+      type: object
+      required: [displayName]
+      properties:
+        displayName: { type: string }
+        email: { type: string, format: email }
+        phone: { type: string }
+    JobTemplate:
+      type: object
+      required: [id, organizationId, templateCode, name, jobType, billingModel]
+      properties:
+        id: { type: string }
+        organizationId: { type: string }
+        templateCode: { type: string }
+        name: { type: string }
+        jobType: { type: string }
+        billingModel: { type: string, examples: [milestone_based] }
+        requiresPhotoVerification: { type: boolean }
+        requiresQaApproval: { type: boolean }
+        allowsPartialInvoicing: { type: boolean }
+        allowsMultiContractorAssignment: { type: boolean }
+        defaultProrationMethod: { type: string, examples: [milestone] }
+        reworkDeductionsEnabled: { type: boolean }
+        isActive: { type: boolean }
+    JobTemplateDetail:
+      allOf:
+        - $ref: '#/components/schemas/JobTemplate'
+        - type: object
+          properties:
+            milestones:
+              type: array
+              items:
+                $ref: '#/components/schemas/TemplateMilestone'
+    CreateJobTemplateRequest:
+      type: object
+      required: [templateCode, name, jobType]
+      properties:
+        templateCode: { type: string }
+        name: { type: string }
+        jobType: { type: string }
+        billingModel: { type: string, default: milestone_based }
+        requiresPhotoVerification: { type: boolean, default: true }
+        requiresQaApproval: { type: boolean, default: true }
+        allowsPartialInvoicing: { type: boolean, default: true }
+        allowsMultiContractorAssignment: { type: boolean, default: true }
+        defaultProrationMethod: { type: string, default: milestone }
+        reworkDeductionsEnabled: { type: boolean, default: true }
+    TemplateMilestone:
+      type: object
+      required: [id, templateId, code, name, percentValue, sortOrder]
+      properties:
+        id: { type: string }
+        templateId: { type: string }
+        code: { type: string }
+        name: { type: string }
+        description: { type: string }
+        percentValue: { type: number }
+        requiresBeforePhoto: { type: boolean }
+        requiresProgressPhoto: { type: boolean }
+        requiresCompletionPhoto: { type: boolean }
+        requiresVoiceNote: { type: boolean }
+        requiresGps: { type: boolean }
+        sortOrder: { type: integer }
+    CreateTemplateMilestoneRequest:
+      type: object
+      required: [code, name, percentValue, sortOrder]
+      properties:
+        code: { type: string }
+        name: { type: string }
+        description: { type: string }
+        percentValue: { type: number }
+        requiresBeforePhoto: { type: boolean, default: false }
+        requiresProgressPhoto: { type: boolean, default: true }
+        requiresCompletionPhoto: { type: boolean, default: true }
+        requiresVoiceNote: { type: boolean, default: false }
+        requiresGps: { type: boolean, default: true }
+        sortOrder: { type: integer }
+    UpdateTemplateMilestoneRequest:
+      type: object
+      properties:
+        code: { type: string }
+        name: { type: string }
+        description: { type: string }
+        percentValue: { type: number }
+        requiresBeforePhoto: { type: boolean }
+        requiresProgressPhoto: { type: boolean }
+        requiresCompletionPhoto: { type: boolean }
+        requiresVoiceNote: { type: boolean }
+        requiresGps: { type: boolean }
+        sortOrder: { type: integer }
+    Job:
+      type: object
+      required: [id, organizationId, templateId, clientId, siteId, jobCode, title, jobTotalValue, status, invoiceStatus]
+      properties:
+        id: { type: string }
+        organizationId: { type: string }
+        templateId: { type: string }
+        clientId: { type: string }
+        siteId: { type: string }
+        jobCode: { type: string }
+        title: { type: string }
+        jobTotalValue:
+          $ref: '#/components/schemas/Money'
+        status:
+          $ref: '#/components/schemas/JobStatus'
+        invoiceStatus:
+          $ref: '#/components/schemas/InvoiceStatus'
+        scheduledDate: { type: string, format: date-time }
+        requiresQa: { type: boolean }
+        allowsPartialInvoicing: { type: boolean }
+    JobDetail:
+      allOf:
+        - $ref: '#/components/schemas/Job'
+        - type: object
+          properties:
+            milestones:
+              type: array
+              items:
+                $ref: '#/components/schemas/JobMilestone'
+    CreateJobRequest:
+      type: object
+      required: [templateId, clientId, siteId, jobCode, title, jobTotalValue]
+      properties:
+        templateId: { type: string }
+        clientId: { type: string }
+        siteId: { type: string }
+        jobCode: { type: string }
+        title: { type: string }
+        jobTotalValue:
+          $ref: '#/components/schemas/Money'
+        scheduledDate: { type: string, format: date-time }
+    JobMilestone:
+      type: object
+      required: [id, jobId, code, name, percentValue, moneyValue, status, verifiedCompletionPercent, qaApproved, earnedValue, deductionValue]
+      properties:
+        id: { type: string }
+        jobId: { type: string }
+        templateMilestoneId: { type: string, nullable: true }
+        code: { type: string }
+        name: { type: string }
+        percentValue: { type: number }
+        moneyValue:
+          $ref: '#/components/schemas/Money'
+        status:
+          $ref: '#/components/schemas/MilestoneStatus'
+        verifiedCompletionPercent: { type: number }
+        qaApproved: { type: boolean }
+        earnedValue:
+          $ref: '#/components/schemas/Money'
+        deductionValue:
+          $ref: '#/components/schemas/Money'
+    UpdateJobMilestoneRequest:
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/MilestoneStatus'
+        verifiedCompletionPercent: { type: number }
+        qaApproved: { type: boolean }
+        earnedValue:
+          $ref: '#/components/schemas/Money'
+        deductionValue:
+          $ref: '#/components/schemas/Money'
+    CreateMilestoneAssignmentRequest:
+      type: object
+      required: [contractorId]
+      properties:
+        contractorId: { type: string }
+        splitPercent: { type: number, default: 100 }
+        isPrimary: { type: boolean, default: false }
+    MilestoneAssignment:
+      type: object
+      required: [id, jobMilestoneId, contractorId, splitPercent, isPrimary]
+      properties:
+        id: { type: string }
+        jobMilestoneId: { type: string }
+        contractorId: { type: string }
+        splitPercent: { type: number }
+        isPrimary: { type: boolean }
+    CreateFieldSubmissionRequest:
+      type: object
+      required: [contractorId, submissionType, claimedStatus, claimedCompletionPercent]
+      properties:
+        contractorId: { type: string }
+        submissionType:
+          $ref: '#/components/schemas/SubmissionType'
+        claimedStatus: { type: string, examples: [partial] }
+        claimedCompletionPercent: { type: number }
+        notes: { type: string }
+        readyForQa: { type: boolean, default: false }
+        blockedReason: { type: string }
+        gpsLat: { type: number }
+        gpsLng: { type: number }
+    FieldSubmission:
+      type: object
+      required: [id, jobId, jobMilestoneId, contractorId, submissionType, claimedStatus, claimedCompletionPercent, readyForQa, submittedAt]
+      properties:
+        id: { type: string }
+        jobId: { type: string }
+        jobMilestoneId: { type: string }
+        contractorId: { type: string }
+        submissionType:
+          $ref: '#/components/schemas/SubmissionType'
+        claimedStatus: { type: string }
+        claimedCompletionPercent: { type: number }
+        notes: { type: string }
+        readyForQa: { type: boolean }
+        blockedReason: { type: string }
+        gpsLat: { type: number }
+        gpsLng: { type: number }
+        submittedAt: { type: string, format: date-time }
+        media:
+          type: array
+          items:
+            $ref: '#/components/schemas/SubmissionMedia'
+    CreateMediaPresignRequest:
+      type: object
+      required: [mediaType, fileName, contentType]
+      properties:
+        mediaType:
+          $ref: '#/components/schemas/MediaType'
+        fileName: { type: string }
+        contentType: { type: string }
+    MediaPresignResponse:
+      type: object
+      required: [uploadUrl, storageUrl, method]
+      properties:
+        uploadUrl: { type: string, format: uri }
+        storageUrl: { type: string, format: uri }
+        method: { type: string, enum: [PUT, POST] }
+        headers:
+          type: object
+          additionalProperties: { type: string }
+    AttachMediaRequest:
+      type: object
+      required: [mediaType, url]
+      properties:
+        mediaType:
+          $ref: '#/components/schemas/MediaType'
+        url: { type: string, format: uri }
+    SubmissionMedia:
+      type: object
+      required: [id, submissionId, mediaType, url]
+      properties:
+        id: { type: string }
+        submissionId: { type: string }
+        mediaType:
+          $ref: '#/components/schemas/MediaType'
+        url: { type: string, format: uri }
+    QAQueueItem:
+      type: object
+      required: [jobId, jobCode, milestoneId, milestoneCode, milestoneStatus]
+      properties:
+        jobId: { type: string }
+        jobCode: { type: string }
+        milestoneId: { type: string }
+        milestoneCode: { type: string }
+        milestoneName: { type: string }
+        milestoneStatus:
+          $ref: '#/components/schemas/MilestoneStatus'
+        latestSubmission:
+          $ref: '#/components/schemas/FieldSubmission'
+    CreateQAReviewRequest:
+      type: object
+      required: [jobMilestoneId, reviewerUserId, action]
+      properties:
+        jobMilestoneId: { type: string }
+        submissionId: { type: string }
+        reviewerUserId: { type: string }
+        action:
+          $ref: '#/components/schemas/QAAction'
+        approvedCompletionPct: { type: number }
+        approvedEarnedValue:
+          $ref: '#/components/schemas/Money'
+        deductionApplied:
+          $ref: '#/components/schemas/Money'
+        reviewerNotes: { type: string }
+    QACompletionRequest:
+      type: object
+      required: [approvedCompletionPct]
+      properties:
+        approvedCompletionPct: { type: number }
+        approvedEarnedValue:
+          $ref: '#/components/schemas/Money'
+        reviewerNotes: { type: string }
+    QAReview:
+      type: object
+      required: [id, jobMilestoneId, reviewerUserId, action, createdAt]
+      properties:
+        id: { type: string }
+        jobMilestoneId: { type: string }
+        submissionId: { type: string, nullable: true }
+        reviewerUserId: { type: string }
+        action:
+          $ref: '#/components/schemas/QAAction'
+        approvedCompletionPct: { type: number }
+        approvedEarnedValue:
+          $ref: '#/components/schemas/Money'
+        deductionApplied:
+          $ref: '#/components/schemas/Money'
+        reviewerNotes: { type: string }
+        createdAt: { type: string, format: date-time }
+    ReassignMilestoneRequest:
+      type: object
+      required: [assignments]
+      properties:
+        reason: { type: string }
+        freezeOriginalCredit: { type: boolean, default: true }
+        assignments:
+          type: array
+          items:
+            $ref: '#/components/schemas/CreateMilestoneAssignmentRequest'
+    Invoice:
+      type: object
+      required: [id, jobId, clientId, invoiceType, status, grossAmount, deductions, netAmount]
+      properties:
+        id: { type: string }
+        jobId: { type: string }
+        clientId: { type: string }
+        batchId: { type: string, nullable: true }
+        invoiceNumber: { type: string }
+        invoiceType:
+          $ref: '#/components/schemas/InvoiceType'
+        status:
+          $ref: '#/components/schemas/InvoiceStatus'
+        grossAmount:
+          $ref: '#/components/schemas/Money'
+        deductions:
+          $ref: '#/components/schemas/Money'
+        netAmount:
+          $ref: '#/components/schemas/Money'
+        issuedAt: { type: string, format: date-time }
+        lineItems:
+          type: array
+          items:
+            $ref: '#/components/schemas/InvoiceLineItem'
+    InvoiceLineItem:
+      type: object
+      required: [id, invoiceId, description, amount]
+      properties:
+        id: { type: string }
+        invoiceId: { type: string }
+        jobMilestoneId: { type: string, nullable: true }
+        description: { type: string }
+        amount:
+          $ref: '#/components/schemas/Money'
+    Payout:
+      type: object
+      required: [id, contractorId, jobId, grossEarned, deductions, netPayout, status]
+      properties:
+        id: { type: string }
+        contractorId: { type: string }
+        jobId: { type: string }
+        batchId: { type: string, nullable: true }
+        grossEarned:
+          $ref: '#/components/schemas/Money'
+        deductions:
+          $ref: '#/components/schemas/Money'
+        netPayout:
+          $ref: '#/components/schemas/Money'
+        status:
+          $ref: '#/components/schemas/PayoutStatus'
+    CreateDeductionRequest:
+      type: object
+      required: [reasonCode, amount]
+      properties:
+        jobMilestoneId: { type: string }
+        contractorId: { type: string }
+        reasonCode: { type: string, examples: [FAILED_QA_DEDUCTION] }
+        amount:
+          $ref: '#/components/schemas/Money'
+        notes: { type: string }
+    Deduction:
+      type: object
+      required: [id, jobId, reasonCode, amount]
+      properties:
+        id: { type: string }
+        jobId: { type: string }
+        jobMilestoneId: { type: string, nullable: true }
+        contractorId: { type: string, nullable: true }
+        reasonCode: { type: string }
+        amount:
+          $ref: '#/components/schemas/Money'
+        notes: { type: string }
+    CreateDisputeRequest:
+      type: object
+      required: [jobMilestoneId, reason]
+      properties:
+        jobMilestoneId: { type: string }
+        contractorId: { type: string }
+        reason: { type: string }
+        evidence: { type: string }
+    ResolveDisputeRequest:
+      type: object
+      required: [decision]
+      properties:
+        decision: { type: string }
+        finalAdjustment:
+          $ref: '#/components/schemas/Money'
+    Dispute:
+      type: object
+      required: [id, jobId, jobMilestoneId, reason]
+      properties:
+        id: { type: string }
+        jobId: { type: string }
+        jobMilestoneId: { type: string }
+        contractorId: { type: string, nullable: true }
+        reason: { type: string }
+        evidence: { type: string }
+        decision: { type: string }
+        finalAdjustment:
+          $ref: '#/components/schemas/Money'
+        resolvedAt: { type: string, format: date-time }
+    GenerateWeeklyBatchRequest:
+      type: object
+      required: [weekStart, weekEnd]
+      properties:
+        weekStart: { type: string, format: date-time }
+        weekEnd: { type: string, format: date-time }
+    Batch:
+      type: object
+      required: [id, organizationId, batchCode, weekStart, weekEnd]
+      properties:
+        id: { type: string }
+        organizationId: { type: string }
+        batchCode: { type: string }
+        weekStart: { type: string, format: date-time }
+        weekEnd: { type: string, format: date-time }
+    BatchDetail:
+      allOf:
+        - $ref: '#/components/schemas/Batch'
+        - type: object
+          properties:
+            payouts:
+              type: array
+              items:
+                $ref: '#/components/schemas/Payout'

--- a/Worksie/backend/package-lock.json
+++ b/Worksie/backend/package-lock.json
@@ -1,0 +1,121 @@
+{
+  "name": "worksie-backend",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "worksie-backend",
+      "version": "0.1.0",
+      "dependencies": {
+        "@prisma/client": "^5.22.0"
+      },
+      "devDependencies": {
+        "prisma": "^5.22.0"
+      }
+    },
+    "node_modules/@prisma/client": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.22.0.tgz",
+      "integrity": "sha512-M0SVXfyHnQREBKxCgyo7sffrKttwE6R8PMq330MIUF0pTwjUhLbW84pFDlf06B27XyCR++VtjugEnIHdr07SVA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.13"
+      },
+      "peerDependencies": {
+        "prisma": "*"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prisma/debug": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.22.0.tgz",
+      "integrity": "sha512-AUt44v3YJeggO2ZU5BkXI7M4hu9BF2zzH2iF2V5pyXT/lRTyWiElZ7It+bRH1EshoMRxHgpYg4VB6rCM+mG5jQ==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/engines": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.22.0.tgz",
+      "integrity": "sha512-UNjfslWhAt06kVL3CjkuYpHAWSO6L4kDCVPegV6itt7nD1kSJavd3vhgAEhjglLJJKEdJ7oIqDJ+yHk6qO8gPA==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "5.22.0",
+        "@prisma/engines-version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
+        "@prisma/fetch-engine": "5.22.0",
+        "@prisma/get-platform": "5.22.0"
+      }
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2.tgz",
+      "integrity": "sha512-2PTmxFR2yHW/eB3uqWtcgRcgAbG1rwG9ZriSvQw+nnb7c4uCr3RAcGMb6/zfE88SKlC1Nj2ziUvc96Z379mHgQ==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.22.0.tgz",
+      "integrity": "sha512-bkrD/Mc2fSvkQBV5EpoFcZ87AvOgDxbG99488a5cexp5Ccny+UM6MAe/UFkUC0wLYD9+9befNOqGiIJhhq+HbA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "5.22.0",
+        "@prisma/engines-version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
+        "@prisma/get-platform": "5.22.0"
+      }
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.22.0.tgz",
+      "integrity": "sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "5.22.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/prisma": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.22.0.tgz",
+      "integrity": "sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/engines": "5.22.0"
+      },
+      "bin": {
+        "prisma": "build/index.js"
+      },
+      "engines": {
+        "node": ">=16.13"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      }
+    }
+  }
+}

--- a/Worksie/backend/package.json
+++ b/Worksie/backend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "worksie-backend",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "prisma:validate": "prisma validate --schema prisma/schema.prisma",
+    "prisma:generate": "prisma generate --schema prisma/schema.prisma",
+    "prisma:migrate": "prisma migrate dev --schema prisma/schema.prisma",
+    "db:seed": "node prisma/seed.js"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.22.0"
+  },
+  "devDependencies": {
+    "prisma": "^5.22.0"
+  },
+  "prisma": {
+    "seed": "node prisma/seed.js"
+  }
+}

--- a/Worksie/backend/prisma/schema.prisma
+++ b/Worksie/backend/prisma/schema.prisma
@@ -1,0 +1,457 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+enum UserRole {
+  OWNER
+  ADMIN
+  DISPATCHER
+  QA_REVIEWER
+  CONTRACTOR
+  CLIENT_VIEWER
+}
+
+enum JobStatus {
+  NOT_STARTED
+  SCHEDULED
+  IN_PROGRESS
+  PARTIALLY_COMPLETED_BILLABLE
+  PARTIALLY_COMPLETED_NON_BILLABLE
+  COMPLETED_PENDING_QA
+  COMPLETED_APPROVED
+  REWORK_REQUIRED
+  REASSIGNED
+  FAILED
+  DISPUTED
+  CLOSED
+}
+
+enum MilestoneStatus {
+  NOT_STARTED
+  IN_PROGRESS
+  COMPLETED_PENDING_QA
+  COMPLETED_APPROVED
+  PARTIAL_BILLABLE
+  PARTIAL_NON_BILLABLE
+  REJECTED
+  REWORK_REQUIRED
+  REASSIGNED
+  DISPUTED
+}
+
+enum InvoiceStatus {
+  NOT_INVOICED
+  PARTIAL_INVOICE_READY
+  INVOICE_READY
+  READY_FOR_REVIEW
+  APPROVED
+  SENT
+  PAID
+  HELD
+  DISPUTED
+  VOIDED
+}
+
+enum InvoiceType {
+  FULL
+  PARTIAL
+  PROGRESS
+  REWORK_ADJUSTED
+  MULTI_CONTRACTOR
+  DISPUTED_HOLD
+  WEEKLY_BATCH
+  FINAL_CLOSEOUT
+}
+
+enum PayoutStatus {
+  NOT_READY
+  PENDING_REVIEW
+  APPROVED
+  BATCHED
+  PAID
+  HELD
+  DEDUCTED
+  DISPUTED
+}
+
+enum SubmissionType {
+  PROGRESS_UPDATE
+  COMPLETION
+  REWORK_UPDATE
+  BLOCKED_UPDATE
+}
+
+enum QAAction {
+  APPROVE
+  REJECT
+  PARTIAL_BILLABLE
+  PARTIAL_NON_BILLABLE
+  REQUEST_MORE_PROOF
+  APPLY_DEDUCTION
+  REASSIGN
+  LOCK_INVOICE
+  ESCALATE_DISPUTE
+}
+
+enum MediaType {
+  PHOTO_BEFORE
+  PHOTO_PROGRESS
+  PHOTO_COMPLETION
+  VOICE_NOTE
+  DOCUMENT
+  SIGNATURE
+}
+
+model Organization {
+  id          String       @id @default(cuid())
+  name        String
+  createdAt   DateTime     @default(now())
+  updatedAt   DateTime     @updatedAt
+  auditLogs   AuditLog[]
+  batches     Batch[]
+  clients     Client[]
+  contractors Contractor[]
+  jobs        Job[]
+  sites       Site[]
+  templates   JobTemplate[]
+  users       User[]
+}
+
+model User {
+  id             String      @id @default(cuid())
+  organizationId String
+  email          String      @unique
+  fullName       String
+  role           UserRole
+  isActive       Boolean     @default(true)
+  createdAt      DateTime    @default(now())
+  updatedAt      DateTime    @updatedAt
+  auditLogs      AuditLog[]
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  qaReviews      QAReview[]  @relation("QAReviewer")
+}
+
+model Client {
+  id             String       @id @default(cuid())
+  organizationId String
+  name           String
+  externalRef    String?
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
+  invoices       Invoice[]
+  jobs           Job[]
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  sites          Site[]
+}
+
+model Site {
+  id             String       @id @default(cuid())
+  organizationId String
+  clientId       String
+  name           String
+  address1       String?
+  city           String?
+  state          String?
+  postalCode     String?
+  country        String?
+  lat            Float?
+  lng            Float?
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
+  client         Client       @relation(fields: [clientId], references: [id])
+  jobs           Job[]
+  organization   Organization @relation(fields: [organizationId], references: [id])
+}
+
+model Contractor {
+  id             String                @id @default(cuid())
+  organizationId String
+  displayName    String
+  email          String?
+  phone          String?
+  isActive       Boolean               @default(true)
+  createdAt      DateTime              @default(now())
+  updatedAt      DateTime              @updatedAt
+  assignments    MilestoneAssignment[]
+  deductions     Deduction[]
+  disputes       Dispute[]
+  organization   Organization          @relation(fields: [organizationId], references: [id])
+  payouts        Payout[]
+  submissions    FieldSubmission[]
+}
+
+model JobTemplate {
+  id                              String              @id @default(cuid())
+  organizationId                  String
+  templateCode                    String
+  name                            String
+  jobType                         String
+  billingModel                    String              @default("milestone_based")
+  requiresPhotoVerification       Boolean             @default(true)
+  requiresQaApproval              Boolean             @default(true)
+  allowsPartialInvoicing          Boolean             @default(true)
+  allowsMultiContractorAssignment Boolean             @default(true)
+  defaultProrationMethod          String              @default("milestone")
+  reworkDeductionsEnabled         Boolean             @default(true)
+  isActive                        Boolean             @default(true)
+  createdAt                       DateTime            @default(now())
+  updatedAt                       DateTime            @updatedAt
+  jobs                            Job[]
+  milestones                      TemplateMilestone[]
+  organization                    Organization        @relation(fields: [organizationId], references: [id])
+
+  @@unique([organizationId, templateCode])
+}
+
+model TemplateMilestone {
+  id                      String         @id @default(cuid())
+  templateId              String
+  code                    String
+  name                    String
+  description             String?
+  percentValue            Float
+  requiresBeforePhoto     Boolean        @default(false)
+  requiresProgressPhoto   Boolean        @default(true)
+  requiresCompletionPhoto Boolean        @default(true)
+  requiresVoiceNote       Boolean        @default(false)
+  requiresGps             Boolean        @default(true)
+  sortOrder               Int
+  createdAt               DateTime       @default(now())
+  updatedAt               DateTime       @updatedAt
+  jobMilestones           JobMilestone[]
+  template                JobTemplate    @relation(fields: [templateId], references: [id])
+
+  @@unique([templateId, code])
+}
+
+model Job {
+  id                     String            @id @default(cuid())
+  organizationId         String
+  templateId             String
+  clientId               String
+  siteId                 String
+  jobCode                String
+  title                  String
+  jobTotalValue          Decimal           @db.Decimal(12, 2)
+  status                 JobStatus         @default(NOT_STARTED)
+  invoiceStatus          InvoiceStatus     @default(NOT_INVOICED)
+  scheduledDate          DateTime?
+  requiresQa             Boolean           @default(true)
+  allowsPartialInvoicing Boolean           @default(true)
+  createdAt              DateTime          @default(now())
+  updatedAt              DateTime          @updatedAt
+  auditLogs              AuditLog[]
+  client                 Client            @relation(fields: [clientId], references: [id])
+  deductions             Deduction[]
+  disputes               Dispute[]
+  invoices               Invoice[]
+  milestones             JobMilestone[]
+  organization           Organization      @relation(fields: [organizationId], references: [id])
+  payouts                Payout[]
+  site                   Site              @relation(fields: [siteId], references: [id])
+  submissions            FieldSubmission[]
+  template               JobTemplate       @relation(fields: [templateId], references: [id])
+
+  @@unique([organizationId, jobCode])
+}
+
+model JobMilestone {
+  id                       String                @id @default(cuid())
+  jobId                    String
+  templateMilestoneId      String?
+  code                     String
+  name                     String
+  percentValue             Float
+  moneyValue               Decimal               @db.Decimal(12, 2)
+  status                   MilestoneStatus       @default(NOT_STARTED)
+  verifiedCompletionPercent Float                @default(0)
+  qaApproved               Boolean               @default(false)
+  earnedValue              Decimal               @default(0) @db.Decimal(12, 2)
+  deductionValue           Decimal               @default(0) @db.Decimal(12, 2)
+  createdAt                DateTime              @default(now())
+  updatedAt                DateTime              @updatedAt
+  assignments              MilestoneAssignment[]
+  deductions               Deduction[]
+  disputes                 Dispute[]
+  invoiceLineItems         InvoiceLineItem[]
+  job                      Job                   @relation(fields: [jobId], references: [id])
+  qaReviews                QAReview[]
+  submissions              FieldSubmission[]
+  templateMilestone        TemplateMilestone?     @relation(fields: [templateMilestoneId], references: [id])
+
+  @@unique([jobId, code])
+}
+
+model MilestoneAssignment {
+  id             String       @id @default(cuid())
+  jobMilestoneId String
+  contractorId   String
+  splitPercent   Float        @default(100)
+  isPrimary      Boolean      @default(false)
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
+  contractor     Contractor   @relation(fields: [contractorId], references: [id])
+  jobMilestone   JobMilestone @relation(fields: [jobMilestoneId], references: [id])
+
+  @@unique([jobMilestoneId, contractorId])
+}
+
+model FieldSubmission {
+  id                       String            @id @default(cuid())
+  jobId                    String
+  jobMilestoneId           String
+  contractorId             String
+  submissionType           SubmissionType
+  claimedStatus            String
+  claimedCompletionPercent Float
+  notes                    String?
+  readyForQa               Boolean           @default(false)
+  blockedReason            String?
+  gpsLat                   Float?
+  gpsLng                   Float?
+  submittedAt              DateTime          @default(now())
+  auditLogs                AuditLog[]
+  contractor               Contractor        @relation(fields: [contractorId], references: [id])
+  job                      Job               @relation(fields: [jobId], references: [id])
+  media                    SubmissionMedia[]
+  milestone                JobMilestone      @relation(fields: [jobMilestoneId], references: [id])
+  qaReviews                QAReview[]
+}
+
+model SubmissionMedia {
+  id           String          @id @default(cuid())
+  submissionId String
+  mediaType    MediaType
+  url          String
+  createdAt    DateTime        @default(now())
+  submission   FieldSubmission @relation(fields: [submissionId], references: [id])
+}
+
+model QAReview {
+  id                    String           @id @default(cuid())
+  jobMilestoneId        String
+  submissionId          String?
+  reviewerUserId        String
+  action                QAAction
+  approvedCompletionPct Float?
+  approvedEarnedValue   Decimal?         @db.Decimal(12, 2)
+  deductionApplied      Decimal?         @db.Decimal(12, 2)
+  reviewerNotes         String?
+  createdAt             DateTime         @default(now())
+  milestone             JobMilestone     @relation(fields: [jobMilestoneId], references: [id])
+  reviewer              User             @relation("QAReviewer", fields: [reviewerUserId], references: [id])
+  submission            FieldSubmission? @relation(fields: [submissionId], references: [id])
+}
+
+model Invoice {
+  id            String            @id @default(cuid())
+  jobId         String
+  clientId      String
+  batchId       String?
+  invoiceNumber String?
+  invoiceType   InvoiceType
+  status        InvoiceStatus     @default(READY_FOR_REVIEW)
+  grossAmount   Decimal           @db.Decimal(12, 2)
+  deductions    Decimal           @default(0) @db.Decimal(12, 2)
+  netAmount     Decimal           @db.Decimal(12, 2)
+  issuedAt      DateTime?
+  createdAt     DateTime          @default(now())
+  updatedAt     DateTime          @updatedAt
+  batch         Batch?            @relation(fields: [batchId], references: [id])
+  client        Client            @relation(fields: [clientId], references: [id])
+  job           Job               @relation(fields: [jobId], references: [id])
+  lineItems     InvoiceLineItem[]
+}
+
+model InvoiceLineItem {
+  id             String        @id @default(cuid())
+  invoiceId      String
+  jobMilestoneId String?
+  description    String
+  amount         Decimal       @db.Decimal(12, 2)
+  invoice        Invoice       @relation(fields: [invoiceId], references: [id])
+  milestone      JobMilestone? @relation(fields: [jobMilestoneId], references: [id])
+}
+
+model Payout {
+  id           String       @id @default(cuid())
+  contractorId String
+  jobId        String
+  batchId      String?
+  grossEarned  Decimal      @db.Decimal(12, 2)
+  deductions   Decimal      @default(0) @db.Decimal(12, 2)
+  netPayout    Decimal      @db.Decimal(12, 2)
+  status       PayoutStatus @default(PENDING_REVIEW)
+  createdAt    DateTime     @default(now())
+  updatedAt    DateTime     @updatedAt
+  batch        Batch?       @relation(fields: [batchId], references: [id])
+  contractor   Contractor   @relation(fields: [contractorId], references: [id])
+  job          Job          @relation(fields: [jobId], references: [id])
+}
+
+model Deduction {
+  id             String        @id @default(cuid())
+  jobId          String
+  jobMilestoneId String?
+  contractorId   String?
+  reasonCode     String
+  amount         Decimal       @db.Decimal(12, 2)
+  notes          String?
+  createdAt      DateTime      @default(now())
+  contractor     Contractor?   @relation(fields: [contractorId], references: [id])
+  job            Job           @relation(fields: [jobId], references: [id])
+  milestone      JobMilestone? @relation(fields: [jobMilestoneId], references: [id])
+}
+
+model Dispute {
+  id              String        @id @default(cuid())
+  jobId           String
+  jobMilestoneId  String
+  contractorId    String?
+  reason          String
+  evidence        String?
+  decision        String?
+  finalAdjustment Decimal?      @db.Decimal(12, 2)
+  resolvedAt      DateTime?
+  createdAt       DateTime      @default(now())
+  contractor      Contractor?   @relation(fields: [contractorId], references: [id])
+  job             Job           @relation(fields: [jobId], references: [id])
+  milestone       JobMilestone  @relation(fields: [jobMilestoneId], references: [id])
+}
+
+model Batch {
+  id             String       @id @default(cuid())
+  organizationId String
+  batchCode      String
+  weekStart      DateTime
+  weekEnd        DateTime
+  createdAt      DateTime     @default(now())
+  invoices       Invoice[]
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  payouts        Payout[]
+
+  @@unique([organizationId, batchCode])
+}
+
+model AuditLog {
+  id             String           @id @default(cuid())
+  organizationId String
+  jobId          String?
+  submissionId   String?
+  actorUserId    String?
+  action         String
+  entityType     String
+  entityId       String
+  beforeJson     Json?
+  afterJson      Json?
+  createdAt      DateTime         @default(now())
+  actor          User?            @relation(fields: [actorUserId], references: [id])
+  job            Job?             @relation(fields: [jobId], references: [id])
+  organization   Organization     @relation(fields: [organizationId], references: [id])
+  submission     FieldSubmission? @relation(fields: [submissionId], references: [id])
+}

--- a/Worksie/backend/prisma/seed.js
+++ b/Worksie/backend/prisma/seed.js
@@ -1,0 +1,312 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+const templateCode = 'ada-ramp-wilscot-v1';
+
+const milestones = [
+  {
+    code: 'M1',
+    name: 'Mobilization',
+    description: 'Load tools, equipment, ramp materials, and verify inventory.',
+    percentValue: 12,
+    requiresBeforePhoto: true,
+    requiresProgressPhoto: true,
+    requiresCompletionPhoto: true,
+    requiresVoiceNote: false,
+    requiresGps: true,
+    sortOrder: 1,
+  },
+  {
+    code: 'M2',
+    name: 'Travel / Arrival',
+    description: 'Travel to site, arrive, and confirm site readiness.',
+    percentValue: 10,
+    requiresBeforePhoto: true,
+    requiresProgressPhoto: false,
+    requiresCompletionPhoto: true,
+    requiresVoiceNote: false,
+    requiresGps: true,
+    sortOrder: 2,
+  },
+  {
+    code: 'M3',
+    name: 'Unload / Prep',
+    description: 'Unload materials, stage components, measure, and prep site.',
+    percentValue: 15,
+    requiresBeforePhoto: true,
+    requiresProgressPhoto: true,
+    requiresCompletionPhoto: true,
+    requiresVoiceNote: false,
+    requiresGps: true,
+    sortOrder: 3,
+  },
+  {
+    code: 'M4A',
+    name: 'Base Layout / Frame Start',
+    description: 'Initial structure positioning and layout.',
+    percentValue: 10,
+    requiresBeforePhoto: true,
+    requiresProgressPhoto: true,
+    requiresCompletionPhoto: true,
+    requiresVoiceNote: true,
+    requiresGps: true,
+    sortOrder: 4,
+  },
+  {
+    code: 'M4B',
+    name: 'Ramp Body Assembly',
+    description: 'Main 30–42 ft ramp build.',
+    percentValue: 15,
+    requiresBeforePhoto: false,
+    requiresProgressPhoto: true,
+    requiresCompletionPhoto: true,
+    requiresVoiceNote: true,
+    requiresGps: true,
+    sortOrder: 5,
+  },
+  {
+    code: 'M4C',
+    name: 'Final Ramp Alignment',
+    description: 'Stabilized and aligned ramp structure.',
+    percentValue: 10,
+    requiresBeforePhoto: false,
+    requiresProgressPhoto: true,
+    requiresCompletionPhoto: true,
+    requiresVoiceNote: true,
+    requiresGps: true,
+    sortOrder: 6,
+  },
+  {
+    code: 'M5',
+    name: 'Compliance / Securement',
+    description: 'Hurricane tie-downs, anchors, rails, and security elements.',
+    percentValue: 15,
+    requiresBeforePhoto: false,
+    requiresProgressPhoto: true,
+    requiresCompletionPhoto: true,
+    requiresVoiceNote: true,
+    requiresGps: true,
+    sortOrder: 7,
+  },
+  {
+    code: 'M6',
+    name: 'ADA Step / Closure Kits',
+    description: 'Step install, closure kits, and finish edges.',
+    percentValue: 8,
+    requiresBeforePhoto: false,
+    requiresProgressPhoto: true,
+    requiresCompletionPhoto: true,
+    requiresVoiceNote: true,
+    requiresGps: true,
+    sortOrder: 8,
+  },
+  {
+    code: 'M7',
+    name: 'Final QA / Cleanup',
+    description: 'Final photos, cleanup, and QA approval.',
+    percentValue: 5,
+    requiresBeforePhoto: false,
+    requiresProgressPhoto: false,
+    requiresCompletionPhoto: true,
+    requiresVoiceNote: true,
+    requiresGps: true,
+    sortOrder: 9,
+  },
+];
+
+async function main() {
+  const percentTotal = milestones.reduce((total, milestone) => total + milestone.percentValue, 0);
+
+  if (percentTotal !== 100) {
+    throw new Error(`ADA ramp template milestone percentages must total 100; received ${percentTotal}.`);
+  }
+
+  const organization = await prisma.organization.upsert({
+    where: { id: 'seed-org-worksie' },
+    update: { name: 'Worksie Demo Organization' },
+    create: {
+      id: 'seed-org-worksie',
+      name: 'Worksie Demo Organization',
+    },
+  });
+
+  const owner = await prisma.user.upsert({
+    where: { email: 'owner@worksie.test' },
+    update: {
+      fullName: 'Worksie Owner',
+      role: 'OWNER',
+      organizationId: organization.id,
+    },
+    create: {
+      organizationId: organization.id,
+      email: 'owner@worksie.test',
+      fullName: 'Worksie Owner',
+      role: 'OWNER',
+    },
+  });
+
+  const client = await prisma.client.upsert({
+    where: { id: 'seed-client-wilscot' },
+    update: {
+      name: 'WilScot Demo Client',
+      externalRef: 'CLIENT-WILSCOT',
+      organizationId: organization.id,
+    },
+    create: {
+      id: 'seed-client-wilscot',
+      organizationId: organization.id,
+      name: 'WilScot Demo Client',
+      externalRef: 'CLIENT-WILSCOT',
+    },
+  });
+
+  const site = await prisma.site.upsert({
+    where: { id: 'seed-site-miami-yard' },
+    update: {
+      organizationId: organization.id,
+      clientId: client.id,
+      name: 'Miami Modular Trailer Yard',
+      address1: '100 Demo Yard Rd',
+      city: 'Miami',
+      state: 'FL',
+      postalCode: '33101',
+      country: 'US',
+      lat: 25.7617,
+      lng: -80.1918,
+    },
+    create: {
+      id: 'seed-site-miami-yard',
+      organizationId: organization.id,
+      clientId: client.id,
+      name: 'Miami Modular Trailer Yard',
+      address1: '100 Demo Yard Rd',
+      city: 'Miami',
+      state: 'FL',
+      postalCode: '33101',
+      country: 'US',
+      lat: 25.7617,
+      lng: -80.1918,
+    },
+  });
+
+  const [contractorA, contractorB] = await Promise.all([
+    prisma.contractor.upsert({
+      where: { id: 'seed-contractor-a' },
+      update: {
+        organizationId: organization.id,
+        displayName: 'Contractor A - Mobilization Crew',
+        email: 'contractor.a@worksie.test',
+        phone: '+15550001001',
+      },
+      create: {
+        id: 'seed-contractor-a',
+        organizationId: organization.id,
+        displayName: 'Contractor A - Mobilization Crew',
+        email: 'contractor.a@worksie.test',
+        phone: '+15550001001',
+      },
+    }),
+    prisma.contractor.upsert({
+      where: { id: 'seed-contractor-b' },
+      update: {
+        organizationId: organization.id,
+        displayName: 'Contractor B - Install Crew',
+        email: 'contractor.b@worksie.test',
+        phone: '+15550001002',
+      },
+      create: {
+        id: 'seed-contractor-b',
+        organizationId: organization.id,
+        displayName: 'Contractor B - Install Crew',
+        email: 'contractor.b@worksie.test',
+        phone: '+15550001002',
+      },
+    }),
+  ]);
+
+  const template = await prisma.jobTemplate.upsert({
+    where: {
+      organizationId_templateCode: {
+        organizationId: organization.id,
+        templateCode,
+      },
+    },
+    update: {
+      name: 'ADA Ramp + Step Install - WilScot Trailer',
+      jobType: 'installation',
+      billingModel: 'milestone_based',
+      requiresPhotoVerification: true,
+      requiresQaApproval: true,
+      allowsPartialInvoicing: true,
+      allowsMultiContractorAssignment: true,
+      defaultProrationMethod: 'milestone',
+      reworkDeductionsEnabled: true,
+      isActive: true,
+    },
+    create: {
+      organizationId: organization.id,
+      templateCode,
+      name: 'ADA Ramp + Step Install - WilScot Trailer',
+      jobType: 'installation',
+      billingModel: 'milestone_based',
+      requiresPhotoVerification: true,
+      requiresQaApproval: true,
+      allowsPartialInvoicing: true,
+      allowsMultiContractorAssignment: true,
+      defaultProrationMethod: 'milestone',
+      reworkDeductionsEnabled: true,
+      isActive: true,
+    },
+  });
+
+  // Additive: re-running the seed upserts each milestone in `milestones` but
+  // does not delete milestones removed from this list. Drop the template (or
+  // its milestones) manually if you rename or remove a milestone code.
+  await Promise.all(
+    milestones.map((milestone) =>
+      prisma.templateMilestone.upsert({
+        where: {
+          templateId_code: {
+            templateId: template.id,
+            code: milestone.code,
+          },
+        },
+        update: milestone,
+        create: {
+          templateId: template.id,
+          ...milestone,
+        },
+      }),
+    ),
+  );
+
+  await prisma.auditLog.create({
+    data: {
+      organizationId: organization.id,
+      actorUserId: owner.id,
+      action: 'SEED_ADA_RAMP_TEMPLATE',
+      entityType: 'JobTemplate',
+      entityId: template.id,
+      afterJson: {
+        templateCode,
+        milestoneCount: milestones.length,
+        percentTotal,
+        seededClientId: client.id,
+        seededSiteId: site.id,
+        seededContractorIds: [contractorA.id, contractorB.id],
+      },
+    },
+  });
+
+  console.log(`Seeded ${template.name} with ${milestones.length} milestones for ${organization.name}.`);
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
Closing as a duplicate of #6.

This PR's tree is content-identical to PR #6's current head (`8f912d7` at the time #11 was opened) — `git diff` between the two branches was empty. PR #6 has the full review history (Codex + Copilot) and the follow-up issues (#7–#10) referenced against it.

The OpenAPI 3.1 `nullable` lint failure noted in this PR's description has been fixed on PR #6 in commit `3399546`:

> Replace OpenAPI 3.0 nullable with 3.1 type-array idiom
> Verified with `npx @redocly/cli lint docs/openapi.yaml`: "Your API description is valid."

Please continue review on #6.