### PR TITLE
Add ESLint config and fix invalid 3DPreview component identifier

### DIFF
--- a/Worksie/.eslintrc.cjs
+++ b/Worksie/.eslintrc.cjs
@@ -1,0 +1,30 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2020: true,
+  },
+  extends: [
+    'eslint:recommended',
+    'plugin:react/recommended',
+    'plugin:react-hooks/recommended',
+  ],
+  ignorePatterns: ['dist/', 'node_modules/'],
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+  plugins: ['react-refresh'],
+  rules: {
+    'react/react-in-jsx-scope': 'off',
+    'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+  },
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
+};

--- a/Worksie/src/components/3DPreview.jsx
+++ b/Worksie/src/components/3DPreview.jsx
@@ -1,1 +1,5 @@
-const 3DPreview = () => { return <div>3DPreview Component</div>; }; export default 3DPreview;
+const ThreeDPreview = () => {
+  return <div>3DPreview Component</div>;
+};
+
+export default ThreeDPreview;


### PR DESCRIPTION
### Motivation
- Make the frontend project lintable and eliminate a parsing error caused by an invalid JavaScript identifier so automated checks and local developer tooling run cleanly.

### Description
- Add a root ESLint configuration at `Worksie/.eslintrc.cjs` with React and React Hooks recommended rules, JSX parser options, and ignored generated/dependency folders.
- Fix the invalid component identifier by renaming the internal export in `Worksie/src/components/3DPreview.jsx` from `3DPreview` to `ThreeDPreview` while keeping the file name unchanged.

### Testing
- Ran `cd Worksie && npm run lint` which completed successfully after the fixes, and `cd Worksie && npm run build` which also completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdda2434ec8322893f774f57a586a7)