### PR TITLE
Repo readiness bootstrap: foundational docs + close SW config footgun

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,15 @@ build/
 
 # Firebase
 .firebase/
+.firebase-debug.log
 
 # Environment variables
 .env
+.env.local
+*.local
+
+# Local Firebase messaging service-worker config (see docs/SECURITY.md)
+Worksie/public/firebase-messaging-sw-config.js
 
 # OS files
 .DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,76 @@
+# AGENTS.md — Worksie Agent Roster
+
+Worksie ships with a set of prompt-defined agents that automate specific
+parts of the product workflow. The prompt files live in
+`Worksie/prompts/`. The training schema they share lives in
+`Worksie/dataset/worksie_training_schema.jsonl`.
+
+This document describes what each agent owns. It is intended for both
+humans and AI coding tools — when a task matches an agent's stated
+scope, prefer using or extending that agent rather than inventing a new
+one.
+
+---
+
+## Roster
+
+### 1. Blueprint Mapper
+- Prompt: `Worksie/prompts/prompt_blueprint_mapper.md`
+- Role: Translates a Worksie product blueprint (PRD-like spec or
+  uploaded design) into a concrete component / page / data-model plan
+  the rest of the system can scaffold.
+- Inputs: PRD text, design references, or a partial component tree.
+- Outputs: A structured plan of files to create or update under
+  `Worksie/src/`, plus suggested data shapes.
+
+### 2. Deployment Trigger
+- Prompt: `Worksie/prompts/prompt_deployment_trigger.md`
+- Role: Owns the deploy path. Reads `Worksie/scripts/deploy.sh`,
+  `Worksie/firebase.json`, and the Firebase Remote Config in
+  `config/worksie-remote-config.json` to validate a release candidate
+  before deploying to Firebase Hosting.
+- Inputs: Current branch state, build output, Firebase project ID.
+- Outputs: Deploy decision (go/no-go) with reasoning, and the exact
+  commands to run.
+- See `docs/DEPLOYMENT.md`.
+
+### 3. UI Designer (Vibe Designer)
+- Prompt: `Worksie/prompts/prompt_ui_designer.md`
+- Role: Generates and refines UI for Worksie surfaces — color, layout,
+  Tailwind classes, component composition. Operates within the scaffold
+  produced by the Blueprint Mapper.
+- Inputs: Component name, target page, brand cues, Remote Config keys.
+- Outputs: JSX + Tailwind for the target component, respecting the
+  `--primary-color` CSS variable driven by Firebase Remote Config.
+
+### 4. Training Orchestrator
+- Prompt: `Worksie/prompts/prompt_training_orchestrator.md`
+- Role: Maintains and extends `Worksie/dataset/worksie_training_schema.jsonl`.
+  Coordinates dataset additions so the schema stays consistent across
+  releases.
+- Inputs: New training examples, schema diffs.
+- Outputs: Validated JSONL entries appended in-place; never rewrites
+  existing entries without an explicit user instruction.
+
+---
+
+## How to use these agents
+
+1. Identify which agent owns the task (UI? scaffolding? deploy? data?).
+2. Open the matching prompt file in `Worksie/prompts/`.
+3. Run the agent with the task description and any relevant repo
+   context (PRD section, current component file, etc.).
+4. Treat the agent's output as a proposal — review before applying.
+
+## Out-of-scope for these agents
+
+These four prompts do not cover:
+
+- Authentication flow design (see `docs/DESIGN.md` once written).
+- Stripe payment flow (no agent owns this yet).
+- CRM data model (no agent owns this yet).
+- Security review (handled by humans + `docs/SECURITY.md`).
+
+If a task falls outside the roster above, do not silently extend a
+prompt to cover it. Either propose a new agent in `docs/DECISIONS.md`
+or handle the task directly with the user.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,105 @@
+# CLAUDE.md — Agent Guardrails for Worksie
+
+This file tells Claude Code (and other AI coding agents) what they need to
+know before touching this repository. Read it in full before making any
+change. If something here conflicts with a user instruction, surface the
+conflict — do not silently override these rules.
+
+---
+
+## 1. Repo layout (read this first)
+
+This repository has a **nested layout**:
+
+```
+worksie/                  <- git repo root
+├── CLAUDE.md             <- this file
+├── AGENTS.md
+├── README.md             <- root pointer
+├── docs/                 <- product, design, security, deployment, ADRs
+├── config/               <- Firebase Remote Config JSON
+└── Worksie/              <- THE ACTUAL APPLICATION
+    ├── package.json
+    ├── src/
+    ├── public/
+    ├── scripts/
+    ├── prompts/
+    ├── dataset/
+    └── docs/             <- legacy app-level doc(s); prefer root /docs
+```
+
+The app does **not** live at the repo root. All `npm`, `vite`, and
+`firebase` commands must run from `Worksie/`, not from the repo root.
+
+---
+
+## 2. Current status of the codebase
+
+As of this writing the project is **scaffold-stage**:
+
+- React 18 + Vite + TailwindCSS frontend
+- Firebase Hosting + Firebase Cloud Messaging + Firebase Remote Config wired
+- Stripe dependencies installed but no payment flow implemented
+- Most components and pages in `Worksie/src/` are **1–5-line stubs**
+  (e.g. `<div>Login Form</div>`). They are placeholders, not features.
+- No tests exist. No CI exists. No typecheck (project is plain JS/JSX).
+- `npm run lint` is the only automated check available.
+
+Do not assume a stubbed component is implemented just because it is
+imported or routed. Read the file before extending it.
+
+---
+
+## 3. What agents may do without asking
+
+- Read any file in the repo.
+- Run `npm run lint` and `npm run build` inside `Worksie/`.
+- Create new files under `docs/` for product/design notes.
+- Edit `docs/CHANGELOG.md` to record completed work.
+
+## 4. What agents must NOT do without explicit user approval
+
+- Commit, push, or force-push.
+- Add, remove, or upgrade dependencies in `Worksie/package.json`.
+- Introduce a new framework, language, or build tool.
+- Implement product features unless the user has named the feature.
+- Rewire Firebase configuration, Stripe, or auth.
+- Add CI workflows, pre-commit hooks, or test runners.
+- Create `.env`, `.env.local`, or any file containing real API keys,
+  tokens, VAPID keys, service-account JSON, or Stripe secrets.
+- Hand-edit `Worksie/public/firebase-messaging-sw.js` to embed real
+  Firebase config values. See `docs/SECURITY.md` for the approved
+  pattern.
+- Delete or overwrite `Worksie/dataset/` or `Worksie/prompts/` files.
+- Restructure the nested `Worksie/` layout.
+
+## 5. Build & validation commands
+
+From `Worksie/`:
+
+```bash
+npm install           # if node_modules missing
+npm run lint          # ESLint, --max-warnings 0
+npm run build         # Vite production build
+npm run dev           # local dev server (not for agents)
+npm run preview       # preview a built bundle
+```
+
+There are no tests. Do not invent a test command.
+
+## 6. Secrets policy (short version)
+
+- Never commit a real API key, VAPID key, Stripe key, Firebase
+  service-account JSON, or `.env*` file.
+- The Firebase web config values (`apiKey`, `authDomain`, etc.) are
+  technically public, but they still must be supplied via env vars so
+  that different environments can use different Firebase projects.
+- See `docs/SECURITY.md` for the service-worker config pattern and the
+  full rules.
+
+## 7. When in doubt
+
+- Prefer reading `docs/PRD.md` and `docs/ROADMAP.md` to infer scope.
+- Prefer asking the user one short clarifying question over guessing.
+- Prefer editing existing files over creating new ones.
+- Prefer the smallest correct change.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,66 @@
+# Worksie
+
+Worksie is a field-operations platform for service businesses — combining
+project documentation, CRM, scheduling, payments, and AI-generated reports
+into one product.
+
+> **Status: scaffold-stage.** The application skeleton, build pipeline,
+> Firebase wiring, and Remote Config are in place. Most UI components and
+> pages are stubs awaiting implementation. See `docs/ROADMAP.md` for the
+> current plan.
+
+---
+
+## Where things live
+
+This repository uses a **nested layout**:
+
+| Path | Contents |
+|---|---|
+| `Worksie/` | The actual React + Vite application. All `npm` commands run here. |
+| `config/` | Firebase Remote Config JSON used by the deploy flow. |
+| `docs/` | Product, design, security, deployment, and decision docs. |
+| `CLAUDE.md` | Guardrails for AI coding agents. Read before automating changes. |
+| `AGENTS.md` | The four prompt-defined agents that ship with Worksie. |
+
+For a current snapshot of the application tree, see
+`Worksie/docs/worksie_folder_structure.txt`.
+
+---
+
+## Getting started
+
+```bash
+git clone <this repo>
+cd worksie/Worksie         # note the nested directory
+cp .env.example .env       # fill in your Firebase project values
+npm install
+npm run dev
+```
+
+Validation commands (run from `Worksie/`):
+
+```bash
+npm run lint
+npm run build
+```
+
+There are no automated tests yet.
+
+---
+
+## Read next
+
+- `docs/PRD.md` — product scope and target user.
+- `docs/ROADMAP.md` — what's stub vs. real, and what ships next.
+- `docs/DESIGN.md` — architecture and data-flow overview.
+- `docs/SECURITY.md` — env-var policy and the Firebase service-worker pattern.
+- `docs/DEPLOYMENT.md` — how releases reach Firebase Hosting.
+- `docs/DECISIONS.md` — architecture decision records (ADRs).
+- `docs/CHANGELOG.md` — release history.
+
+---
+
+## License
+
+Not yet declared. See `docs/DECISIONS.md` for the open question.

--- a/Worksie/.env.example
+++ b/Worksie/.env.example
@@ -1,0 +1,33 @@
+# Worksie — environment variable template
+#
+# 1. Copy this file to `.env` (which is gitignored):
+#      cp .env.example .env
+# 2. Fill in the values for your Firebase project. The web config
+#    values are visible to end users in the deployed bundle, but they
+#    still belong in env so different environments use different
+#    Firebase projects.
+# 3. Never commit `.env`, `.env.local`, or any file containing real
+#    secret keys.
+#
+# See docs/SECURITY.md for the full policy.
+
+# --- Firebase web app config ---------------------------------------
+# Found at Firebase Console → Project settings → General → Your apps
+VITE_FIREBASE_API_KEY=
+VITE_FIREBASE_AUTH_DOMAIN=
+VITE_FIREBASE_PROJECT_ID=
+VITE_FIREBASE_STORAGE_BUCKET=
+VITE_FIREBASE_MESSAGING_SENDER_ID=
+VITE_FIREBASE_APP_ID=
+
+# --- Firebase Cloud Messaging --------------------------------------
+# VAPID *public* key. Found at Firebase Console → Project settings →
+# Cloud Messaging → Web configuration → Web Push certificates.
+# The matching private key stays in Firebase and must NEVER be
+# committed or pasted into client code.
+VITE_FIREBASE_VAPID_KEY=
+
+# --- Stripe (frontend) ---------------------------------------------
+# Publishable key only (starts with pk_test_ or pk_live_).
+# Secret keys (sk_*) live server-side, never in this file.
+VITE_STRIPE_PUBLISHABLE_KEY=

--- a/Worksie/.gitignore
+++ b/Worksie/.gitignore
@@ -7,3 +7,4 @@
 *.log
 .env
 .env.*
+!.env.example

--- a/Worksie/README.md
+++ b/Worksie/README.md
@@ -1,8 +1,22 @@
-# 🛠 Worksie App
+# Worksie App
 
-Worksie is a full-stack field operations platform built to outpace tools like CompanyCam by integrating advanced project documentation, CRM, scheduling, payment processing, and AI-powered reports into one system.
+Worksie is a field-operations platform combining project documentation,
+CRM, scheduling, payments, and AI-generated reports into one product.
 
-## 🚀 Features
+> **This `Worksie/` directory is the actual application.** The
+> repository root above it holds `docs/`, `config/`, and the agent
+> guardrails (`CLAUDE.md`, `AGENTS.md`). All `npm` and `firebase`
+> commands run from inside this directory.
+
+> **Status: scaffold-stage.** The build pipeline, Firebase wiring, and
+> Remote Config are in place. Most components and pages in `src/` are
+> 1–5 line placeholders. See `../docs/ROADMAP.md` for what's planned
+> vs. what's real.
+
+---
+
+## Intended features (most still stubs — see PRD/ROADMAP)
+
 - GPS-tagged photo & video capture
 - 3D LiDAR scan + floorplan generation
 - AI-generated job reports (PDF)
@@ -11,106 +25,109 @@ Worksie is a full-stack field operations platform built to outpace tools like Co
 - Stripe-integrated payments + invoices
 - Template marketplace for checklists & forms
 
-## 📁 Folder Structure
-Organized by the Soulful Coder 6-Pillar System:
+## Folder layout (this directory)
 
 ```
-src/
-├── components/
-├── pages/
-├── logic/
-├── hooks/
-├── context/
-public/
-assets/
-prompts/
-dataset/
-docs/
-scripts/
+Worksie/
+├── src/
+│   ├── components/    (mostly stubs)
+│   ├── pages/         (mostly stubs)
+│   ├── logic/         firebase.js, remoteConfig.js
+│   ├── App.jsx
+│   ├── main.jsx
+│   └── routes.jsx
+├── public/            firebase-messaging-sw.js + (untracked) config
+├── prompts/           four prompt-defined agents (see ../AGENTS.md)
+├── dataset/           worksie_training_schema.jsonl
+├── scripts/           deploy.sh
+├── docs/              legacy app-level notes (prefer root /docs)
+├── package.json
+├── vite.config.js
+├── tailwind.config.js
+├── postcss.config.js
+├── firebase.json
+└── .env.example
 ```
 
-## 📦 Tech Stack
-- React + TailwindCSS
-- Firebase Hosting + Firestore
-- Stripe API, Claude + GPT agents
-- Replit for frontend & compute
+## Tech stack
 
-## 🧠 Claude Agent Prompts
-Stored in `/prompts`:
-- blueprint_mapper_agent
-- deployment_trigger_agent
-- vibe_designer_agent
-- training_orchestrator_agent
+- React 18 + Vite 4
+- TailwindCSS 3
+- Firebase Hosting + Cloud Messaging + Remote Config
+- Stripe SDK (frontend only; flow not implemented)
+- react-router-dom v6
 
-## ⚙️ Local Setup
+## Local setup
 
 ```bash
-git clone https://github.com/YOUR_USERNAME/worksie.git
-cd worksie
+# from this Worksie/ directory:
+cp .env.example .env
+# fill in your Firebase web config values in .env
+
+# the Firebase messaging service worker uses an untracked sibling
+# config because it cannot read Vite env vars at runtime:
+cp public/firebase-messaging-sw-config.example.js \
+   public/firebase-messaging-sw-config.js
+# fill in the same Firebase values inside that new file
+
 npm install
 npm run dev
 ```
 
-## 🔁 Deploy to Firebase
+Validation:
+
+```bash
+npm run lint    # ESLint, --max-warnings 0
+npm run build   # production bundle to dist/
+```
+
+There are no tests yet.
+
+## Deploy
+
 ```bash
 npm run build
-firebase deploy
+firebase deploy --only hosting
+# or:
+./scripts/deploy.sh
 ```
 
-## 🤖 Train with Claude
-Upload `worksie_training_schema.jsonl` and prompts into Claude Code and run:
-```txt
-"Use this schema and these agents to scaffold Worksie as a full-stack Firebase + React app."
-```
+See `../docs/DEPLOYMENT.md` for the full deploy and Remote Config
+flow.
 
-## 🔥 Firebase Configuration
+## Firebase configuration
 
-This project uses Firebase for push notifications. To connect to your Firebase project, you will need to set up your environment variables.
+Firebase web config values are read from environment variables. See
+`.env.example` for the canonical list, and `../docs/SECURITY.md` for
+the policy (no real keys in source, no `.env` in git, no real config
+pasted into the service worker).
 
-1.  **Create a `.env` file:** In the root of the `Worksie` directory, create a new file named `.env`.
+The service worker (`public/firebase-messaging-sw.js`) loads its
+Firebase config from `public/firebase-messaging-sw-config.js`, which
+is **gitignored**. Use the `.example.js` template to create it
+locally.
 
-2.  **Add your Firebase credentials:** Copy the contents of `.env.example` into your new `.env` file and replace the placeholder values with your actual Firebase project credentials.
+## Firebase Remote Config
 
-    ```
-    VITE_FIREBASE_API_KEY="YOUR_API_KEY"
-    VITE_FIREBASE_AUTH_DOMAIN="YOUR_AUTH_DOMAIN"
-    VITE_FIREBASE_PROJECT_ID="YOUR_PROJECT_ID"
-    VITE_FIREBASE_STORAGE_BUCKET="YOUR_STORAGE_BUCKET"
-    VITE_FIREBASE_MESSAGING_SENDER_ID="YOUR_MESSAGING_SENDER_ID"
-    VITE_FIREBASE_APP_ID="YOUR_APP_ID"
-    ```
+Live values live in the repo root at `../config/worksie-remote-config.json`
+and are pushed out-of-band (see `../docs/DEPLOYMENT.md`). The frontend
+reads three keys today: `promo_banner_enabled`, `promo_banner_text`,
+and `app_primary_color`.
 
-3.  **Configure the Service Worker:** The Firebase service worker (`public/firebase-messaging-sw.js`) cannot access environment variables directly. You must manually open this file and replace the placeholder Firebase credentials with your actual project credentials.
+## Claude / agent prompts
 
-Once you have completed these steps, the application will be able to connect to your Firebase project and receive push notifications.
+The four agents shipped with Worksie are documented in `../AGENTS.md`.
+Their prompts live in `prompts/`. Their shared training schema lives
+in `dataset/worksie_training_schema.jsonl`.
 
-## 📡 Firebase Remote Config
+## Where to read next
 
-This project uses Firebase Remote Config to allow for dynamic configuration of the application. The configuration is stored in the `config/worksie-remote-config.json` file.
-
-### Importing the Configuration
-
-You can import this configuration into your Firebase project using the Firebase CLI or the REST API.
-
-**Using the REST API (example):**
-
-1.  **Get an access token:**
-    ```bash
-    ACCESS_TOKEN=$(gcloud auth print-access-token)
-    ```
-
-2.  **Push the configuration:**
-    ```bash
-    curl -X PUT \
-     -H "Authorization: Bearer $ACCESS_TOKEN" \
-     -H "Content-Type: application/json; UTF-8" \
-     -d @config/worksie-remote-config.json \
-     "https://firebaseremoteconfig.googleapis.com/v1/projects/YOUR_PROJECT_ID/remoteConfig"
-    ```
-    (Replace `YOUR_PROJECT_ID` with your actual Firebase project ID.)
-
-### Using the Configuration in the App
-
-The application is already set up to fetch and use the Remote Config values. The main logic is in `src/logic/remoteConfig.js`.
-
-The `PromoBanner` component and the primary color are currently controlled by Remote Config. You can extend this to other parts of the application as needed.
+- `../CLAUDE.md` — agent guardrails (read before automating changes).
+- `../AGENTS.md` — agent roster.
+- `../docs/PRD.md` — product scope.
+- `../docs/ROADMAP.md` — phase plan.
+- `../docs/DESIGN.md` — architecture.
+- `../docs/SECURITY.md` — secrets policy.
+- `../docs/DEPLOYMENT.md` — deploy + Remote Config.
+- `../docs/DECISIONS.md` — ADRs and open questions.
+- `../docs/CHANGELOG.md` — release notes.

--- a/Worksie/docs/worksie_folder_structure.txt
+++ b/Worksie/docs/worksie_folder_structure.txt
@@ -1,78 +1,103 @@
+Worksie — current source tree snapshot
+======================================
+
+This file is a manually-maintained snapshot of the application
+directory. It supersedes earlier versions that referenced files which
+no longer exist (e.g. replit.nix, generate_jsonl.py, src/hooks/,
+src/context/, assets/). Re-export when the tree changes meaningfully.
+
+Repository root
+---------------
+worksie/
+├── CLAUDE.md                       agent guardrails
+├── AGENTS.md                       agent roster
+├── README.md                       root pointer
+├── .gitignore
+├── config/
+│   └── worksie-remote-config.json  Firebase Remote Config values
+├── docs/                           foundational docs (PRD, ROADMAP, …)
+└── Worksie/                        THE APPLICATION (everything below)
+
+Worksie/ — the application
+--------------------------
 Worksie/
-  └── README.md
-  └── .env
-  └── firebase.json
-  └── package.json
-  └── replit.nix
-  └── .replit
-  └── public/
-  └── assets/
-  └── docs/
-  └── dataset/
-  └── prompts/
-  └── scripts/
-  └── src/
-Worksie/public/
-  └── index.html
-  └── favicon.ico
-  └── manifest.json
-Worksie/assets/
-  └── logo.png
-  └── background.jpg
-  └── icons/
-Worksie/docs/
-  └── component_reference.md
-  └── dev_handoff_notes.md
-  └── api_integration_guide.md
-Worksie/dataset/
-  └── worksie_training_schema.jsonl
-Worksie/prompts/
-  └── prompt_blueprint_mapper.md
-  └── prompt_deployment_trigger.md
-  └── prompt_ui_designer.md
-Worksie/scripts/
-  └── deploy.sh
-  └── generate_jsonl.py
-Worksie/src/
-  └── main.jsx
-  └── App.jsx
-  └── routes.jsx
-  └── components/
-  └── pages/
-  └── logic/
-  └── hooks/
-  └── context/
-Worksie/src/components/
-  └── LoginForm.jsx
-  └── SignupForm.jsx
-  └── UserProfile.jsx
-  └── AvatarUpload.jsx
-  └── MediaCapture.jsx
-  └── Annotator.jsx
-  └── GalleryViewer.jsx
-  └── LiDARScanner.jsx
-  └── AutoReportBuilder.jsx
-  └── ChecklistBuilder.jsx
-Worksie/src/pages/
-  └── Home.jsx
-  └── Dashboard.jsx
-  └── Reports.jsx
-  └── Tasks.jsx
-  └── CRM.jsx
-  └── Settings.jsx
-  └── Support.jsx
-Worksie/src/logic/
-  └── auth.js
-  └── firestore.js
-  └── stripe.js
-  └── reportBuilder.js
-  └── roleManager.js
-  └── scanProcessor.js
-Worksie/src/hooks/
-  └── useAuth.js
-  └── useUpload.js
-  └── useReportGen.js
-Worksie/src/context/
-  └── AuthContext.js
-  └── UserContext.js
-  └── ThemeContext.js
+├── README.md
+├── package.json
+├── package-lock.json
+├── index.html
+├── firebase.json
+├── vite.config.js
+├── tailwind.config.js
+├── postcss.config.js
+├── .eslintrc.cjs
+├── .gitignore
+├── .env.example
+├── dataset/
+│   └── worksie_training_schema.jsonl
+├── prompts/
+│   ├── prompt_blueprint_mapper.md
+│   ├── prompt_deployment_trigger.md
+│   ├── prompt_training_orchestrator.md
+│   └── prompt_ui_designer.md
+├── scripts/
+│   └── deploy.sh
+├── public/
+│   ├── firebase-messaging-sw.js
+│   └── firebase-messaging-sw-config.example.js
+│   (firebase-messaging-sw-config.js is created locally and gitignored)
+├── docs/
+│   └── worksie_folder_structure.txt    (this file)
+└── src/
+    ├── main.jsx
+    ├── App.jsx
+    ├── routes.jsx
+    ├── index.css
+    ├── logic/
+    │   ├── firebase.js
+    │   └── remoteConfig.js
+    ├── pages/
+    │   ├── Home.jsx
+    │   ├── Dashboard.jsx
+    │   ├── Reports.jsx
+    │   ├── Tasks.jsx
+    │   ├── CRM.jsx
+    │   ├── Settings.jsx
+    │   └── Support.jsx
+    └── components/
+        ├── 3DPreview.jsx
+        ├── AdminHome.jsx
+        ├── AnalyticsChart.jsx
+        ├── Annotator.jsx
+        ├── AutoReportBuilder.jsx
+        ├── AvatarUpload.jsx
+        ├── CRMLeadForm.jsx
+        ├── CalendarView.jsx
+        ├── ChatWindow.jsx
+        ├── ChecklistBuilder.jsx
+        ├── FloorplanAutoGen.jsx
+        ├── GalleryViewer.jsx
+        ├── InvoiceBuilder.jsx
+        ├── LiDARScanner.jsx
+        ├── LoginForm.jsx
+        ├── MediaCapture.jsx
+        ├── PDFExporter.jsx
+        ├── PipelineView.jsx
+        ├── ProjectOverview.jsx
+        ├── PromoBanner.jsx
+        ├── RoleSelector.jsx
+        ├── SignupForm.jsx
+        ├── SupportForm.jsx
+        ├── TaskBoard.jsx
+        ├── TemplateMarket.jsx
+        ├── ToastNotification.jsx
+        └── UserProfile.jsx
+
+Notes
+-----
+- src/hooks/ and src/context/ do NOT exist today. Add only when there
+  is a concrete consumer.
+- Almost every file in src/components/ and src/pages/ is a 1–5 line
+  placeholder. Read before extending.
+- public/firebase-messaging-sw-config.js is intentionally absent from
+  git. Create it locally from the .example.js template. See
+  docs/SECURITY.md.

--- a/Worksie/public/firebase-messaging-sw-config.example.js
+++ b/Worksie/public/firebase-messaging-sw-config.example.js
@@ -1,0 +1,22 @@
+// Template for `firebase-messaging-sw-config.js`.
+//
+// The Firebase messaging service worker (`firebase-messaging-sw.js`)
+// runs in a context that cannot read Vite env vars, so it imports its
+// Firebase web config from this sibling file at runtime.
+//
+// Setup:
+//   1. Copy this file to `firebase-messaging-sw-config.js` in the same
+//      directory. That target filename is gitignored on purpose.
+//   2. Replace the __PLACEHOLDER__ values with the same Firebase web
+//      config values you put in `Worksie/.env` (the keys must match).
+//
+// Do NOT commit `firebase-messaging-sw-config.js`. See docs/SECURITY.md.
+
+self.__WORKSIE_FIREBASE_CONFIG__ = {
+  apiKey: "__FIREBASE_API_KEY__",
+  authDomain: "__FIREBASE_AUTH_DOMAIN__",
+  projectId: "__FIREBASE_PROJECT_ID__",
+  storageBucket: "__FIREBASE_STORAGE_BUCKET__",
+  messagingSenderId: "__FIREBASE_MESSAGING_SENDER_ID__",
+  appId: "__FIREBASE_APP_ID__",
+};

--- a/Worksie/public/firebase-messaging-sw.js
+++ b/Worksie/public/firebase-messaging-sw.js
@@ -1,33 +1,46 @@
-// IMPORTANT:
-// This service worker file is in the 'public' directory and is not processed by Vite.
-// This means it cannot access environment variables and you must replace the placeholder
-// Firebase configuration values below with your actual Firebase project credentials.
+// Firebase Cloud Messaging service worker.
+//
+// This file runs in a worker context that CANNOT read Vite env vars
+// (`import.meta.env` is undefined here). It loads its Firebase web
+// config at runtime from the sibling file
+// `firebase-messaging-sw-config.js`, which is gitignored on purpose.
+//
+// Setup:
+//   1. Copy `firebase-messaging-sw-config.example.js` to
+//      `firebase-messaging-sw-config.js` in this directory.
+//   2. Fill in the same Firebase web config values you put in
+//      `Worksie/.env`.
+//
+// Do NOT paste real Firebase config into this file. See
+// docs/SECURITY.md for the rationale.
 
-// Import and configure the Firebase SDK
+importScripts("./firebase-messaging-sw-config.js");
+
 import { initializeApp } from "firebase/app";
 import { getMessaging, onBackgroundMessage } from "firebase/messaging/sw";
 
-// YOUR FIREBASE CONFIGURATION
-const firebaseConfig = {
-  apiKey: "YOUR_API_KEY",
-  authDomain: "YOUR_AUTH_DOMAIN",
-  projectId: "YOUR_PROJECT_ID",
-  storageBucket: "YOUR_STORAGE_BUCKET",
-  messagingSenderId: "YOUR_MESSAGING_SENDER_ID",
-  appId: "YOUR_APP_ID"
-};
+const firebaseConfig = self.__WORKSIE_FIREBASE_CONFIG__;
+
+if (!firebaseConfig || !firebaseConfig.apiKey) {
+  // Surface a clear error instead of silently failing. The service
+  // worker will still register, but push notifications will not work
+  // until the config file is in place.
+  console.error(
+    "[firebase-messaging-sw] Missing firebase-messaging-sw-config.js. " +
+      "Copy firebase-messaging-sw-config.example.js and fill in your " +
+      "Firebase web config. See docs/SECURITY.md."
+  );
+}
 
 const app = initializeApp(firebaseConfig);
 const messaging = getMessaging(app);
 
 onBackgroundMessage(messaging, (payload) => {
-  console.log('[firebase-messaging-sw.js] Received background message ', payload);
-  // Customize notification here
-  const notificationTitle = payload.notification.title;
+  console.log("[firebase-messaging-sw] background message", payload);
+  const notificationTitle = payload?.notification?.title ?? "Worksie";
   const notificationOptions = {
-    body: payload.notification.body,
-    icon: '/favicon.ico'
+    body: payload?.notification?.body ?? "",
+    icon: "/favicon.ico",
   };
-
   self.registration.showNotification(notificationTitle, notificationOptions);
 });

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+
+All notable changes to this repository are recorded here. The format
+loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versions are not yet assigned — the project is pre-1.0 scaffold.
+
+## [Unreleased]
+
+### Added
+- `CLAUDE.md` — agent guardrails covering repo layout, allowed actions,
+  build commands, and secrets policy.
+- `AGENTS.md` — roster for the four prompt-defined agents shipped in
+  `Worksie/prompts/`.
+- Root `README.md` — explains the nested `Worksie/` layout, current
+  scaffold-stage status, and points at `docs/`.
+- `docs/PRD.md`, `docs/ROADMAP.md`, `docs/DESIGN.md`, `docs/SECURITY.md`,
+  `docs/DEPLOYMENT.md`, `docs/DECISIONS.md`, `docs/CHANGELOG.md` —
+  foundational documentation set.
+- `Worksie/.env.example` — canonical list of `VITE_FIREBASE_*` and
+  `VITE_STRIPE_PUBLISHABLE_KEY` environment variables.
+- `Worksie/public/firebase-messaging-sw-config.example.js` — template
+  for the new untracked service-worker config file.
+
+### Changed
+- `Worksie/public/firebase-messaging-sw.js` — replaced committed
+  `YOUR_API_KEY`-style placeholders with an import of an untracked
+  sibling config file. Eliminates the footgun that previously
+  encouraged committing real Firebase config.
+- `Worksie/README.md` — clarified nested layout, fixed the missing
+  `.env.example` reference, pointed readers at root-level `docs/`,
+  and called out scaffold/stub status.
+- `Worksie/docs/worksie_folder_structure.txt` — replaced with an
+  accurate snapshot of the current source tree.
+- `.gitignore` — added `.env.local`, `*.local`,
+  `.firebase-debug.log`, and the new untracked SW config file.
+
+### Removed
+- Nothing yet.
+
+### Security
+- Closed the Firebase service-worker placeholder footgun documented
+  during the readiness audit. See `docs/SECURITY.md` §3.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,0 +1,97 @@
+# Worksie — Architecture Decision Records
+
+> Format: lightweight ADRs. One section per decision. Status is one
+> of: **Proposed**, **Accepted**, **Superseded by ADR-NNN**, **Open**.
+> Append new decisions to the bottom — never rewrite history.
+
+---
+
+## ADR-001 — Use Firebase as the backend
+
+- **Status:** Accepted (implicit from the existing scaffold).
+- **Context:** Worksie needs hosting, push, real-time data, auth, and
+  light server compute without staffing a backend team.
+- **Decision:** Use Firebase Hosting, Cloud Messaging, Remote Config,
+  and (planned) Firestore + Auth + Functions.
+- **Consequences:** Vendor lock-in. Pricing scales with usage. Security
+  rules are the only authorization boundary for direct Firestore
+  access. Cloud Functions become the only place to run trusted server
+  logic.
+
+## ADR-002 — Vite + React + JSX, not Next.js, not TypeScript (yet)
+
+- **Status:** Accepted (implicit from `Worksie/package.json`).
+- **Context:** Project started as a quick scaffold; the team wanted a
+  static SPA shipped to Firebase Hosting, not SSR.
+- **Decision:** Vite 4 + React 18 + plain JSX. No Next.js. No
+  TypeScript in v1.
+- **Consequences:** No SSR or RSC. No type-level guarantees. ESLint is
+  the only static check. Phase 1 of the roadmap will revisit whether to
+  migrate to TypeScript.
+
+## ADR-003 — TailwindCSS as the only styling system
+
+- **Status:** Accepted.
+- **Context:** Multiple style systems compound complexity.
+- **Decision:** Tailwind 3, with the design token `--primary-color`
+  driven by Firebase Remote Config. No CSS-in-JS, no second utility
+  library.
+- **Consequences:** Designers and agents must work in Tailwind classes.
+  The UI Designer prompt in `Worksie/prompts/` reflects this.
+
+## ADR-004 — Nested `Worksie/` app layout
+
+- **Status:** Accepted.
+- **Context:** The repo root holds the application (`Worksie/`),
+  configuration (`config/`), and docs (`docs/`). Restructuring to a
+  flat layout would invalidate existing commits and the deploy script.
+- **Decision:** Keep the nested layout. Document it prominently in
+  `README.md` and `CLAUDE.md`.
+- **Consequences:** All `npm` and `firebase` commands run from
+  `Worksie/`. Agents must be told this explicitly.
+
+## ADR-005 — Service-worker config via untracked sibling file
+
+- **Status:** Accepted.
+- **Context:** `Worksie/public/firebase-messaging-sw.js` runs in a
+  context that cannot read Vite env vars. The previous pattern
+  (placeholder strings to be hand-edited and committed) was a recipe
+  for leaking Firebase config.
+- **Decision:** The SW imports its config from
+  `public/firebase-messaging-sw-config.js`, which is gitignored.
+  Developers copy `firebase-messaging-sw-config.example.js` locally and
+  fill in real values.
+- **Consequences:** One extra setup step per environment. Reduced
+  risk of accidentally committing config values. Documented in
+  `docs/SECURITY.md` and `docs/DEPLOYMENT.md`.
+
+## ADR-006 — Four named prompt agents instead of ad-hoc prompting
+
+- **Status:** Accepted.
+- **Context:** Worksie ships four narrowly-scoped prompts in
+  `Worksie/prompts/`. Each owns a specific surface
+  (blueprint-mapping, deploy gating, UI generation, training
+  orchestration).
+- **Decision:** Treat these four as the canonical agent roster. New
+  agents require a new ADR.
+- **Consequences:** `AGENTS.md` is the single source of truth for the
+  roster. Tasks outside the roster are handled directly by humans or
+  by a generic Claude Code session, not by silently extending one of
+  the four prompts.
+
+---
+
+## Open decisions (not yet ADRs)
+
+- **License.** No `LICENSE` file exists. Pick one or declare the repo
+  proprietary.
+- **TypeScript migration.** Decide in Phase 1 of the roadmap.
+- **Test framework.** Vitest is the obvious match for Vite, but the
+  decision hasn't been made.
+- **Firestore as system of record vs. cache.** README implies
+  Firestore is the primary store; no Firestore code exists yet.
+- **PDF rendering location.** Client-side library vs. Cloud Function.
+- **CI provider.** GitHub Actions is the default assumption but not
+  yet configured.
+- **Security disclosure inbox.** `docs/SECURITY.md` currently points
+  to GitHub Security Advisories as a placeholder.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,116 @@
+# Worksie — Deployment
+
+> Status: **draft v0.1**. Covers the deploy path that exists today:
+> Firebase Hosting for the static bundle, plus an out-of-band Remote
+> Config push.
+
+---
+
+## 1. Prerequisites
+
+- A Firebase project with **Hosting**, **Cloud Messaging**, and
+  **Remote Config** enabled.
+- Firebase CLI installed locally (`npm install -g firebase-tools`).
+- Authenticated CLI session (`firebase login`).
+- Optional: `gcloud` CLI if you intend to push Remote Config via the
+  REST API path described below.
+
+## 2. Environment setup (one-time)
+
+1. From `Worksie/`:
+   ```bash
+   cp .env.example .env
+   ```
+2. Fill in the Firebase web config values for the target project.
+3. Create the un-tracked service-worker config:
+   ```bash
+   cp public/firebase-messaging-sw-config.example.js \
+      public/firebase-messaging-sw-config.js
+   ```
+   Then fill in the same values inside the new file. Both files use
+   the same six Firebase web config keys; they must match.
+
+   `firebase-messaging-sw-config.js` is gitignored on purpose. Do not
+   commit it. See `docs/SECURITY.md`.
+
+## 3. Build & deploy
+
+From `Worksie/`:
+
+```bash
+npm install
+npm run build
+firebase deploy --only hosting
+```
+
+`Worksie/scripts/deploy.sh` is a convenience wrapper for the above and
+runs from the same directory.
+
+`Worksie/firebase.json` declares:
+
+- `public`: `dist`
+- Single-page-app rewrite: every path → `/index.html`
+- Ignores `firebase.json`, dotfiles, `**/node_modules/**`
+
+## 4. Remote Config
+
+Live configuration lives in `config/worksie-remote-config.json` at the
+repo root (a sibling of `Worksie/`, not inside it).
+
+### 4.1 Push via Firebase REST API
+
+```bash
+ACCESS_TOKEN=$(gcloud auth print-access-token)
+curl -X PUT \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -H "Content-Type: application/json; UTF-8" \
+  -d @config/worksie-remote-config.json \
+  "https://firebaseremoteconfig.googleapis.com/v1/projects/<PROJECT_ID>/remoteConfig"
+```
+
+### 4.2 What the app reads
+
+Frontend code reads three keys today
+(`Worksie/src/logic/remoteConfig.js` + `App.jsx`):
+
+| Key | Effect |
+|---|---|
+| `promo_banner_enabled` | Toggles the `<PromoBanner />` component. |
+| `promo_banner_text` | Body text shown inside the banner. |
+| `app_primary_color` | Sets the `--primary-color` CSS variable. |
+
+Defaults are seeded in `remoteConfig.js`. The minimum fetch interval is
+**1 hour**. Changes to Remote Config may take that long to appear in
+already-open clients.
+
+## 5. Rollback
+
+There is no automated rollback yet. To revert:
+
+1. **App bundle** — `firebase hosting:clone` or redeploy from a
+   previous commit.
+2. **Remote Config** — Firebase Console → Remote Config → version
+   history → roll back to a previous version.
+
+## 6. CI/CD
+
+Not configured. There is no GitHub Actions workflow today. Phase 1 of
+`docs/ROADMAP.md` plans to add one that runs `npm run lint` and
+`npm run build` on every PR.
+
+## 7. Environments
+
+Only **production** is configured today. Use a separate Firebase
+project (and a separate `.env`) for staging — do not introduce env
+suffixes in code until the second environment exists.
+
+## 8. Things that will bite you
+
+- Forgetting to also create `firebase-messaging-sw-config.js` — the
+  service worker silently fails to deliver push notifications.
+- Editing `Worksie/firebase.json` to add `"functions"` or `"firestore"`
+  blocks before those products are configured — `firebase deploy` will
+  refuse.
+- Deploying without first running `npm run build` — `dist/` may be
+  stale and Hosting will serve an old bundle.
+- Running deploy commands from the repo root instead of `Worksie/`.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,0 +1,113 @@
+# Worksie — Design Overview
+
+> Status: **draft v0.1**. Reflects the system as currently scaffolded
+> in `Worksie/`. Anything marked *planned* is intent, not built.
+
+## 1. High-level architecture
+
+```
+        Browser (mobile-first)
+        ┌────────────────────────────┐
+        │ React 18 + Vite + Tailwind │
+        │  ─ routes (react-router-v6)│
+        │  ─ Remote Config theming   │
+        │  ─ FCM token request       │
+        └─────────────┬──────────────┘
+                      │
+                      ▼
+        ┌────────────────────────────┐
+        │      Firebase Project      │
+        │  ─ Hosting (static dist/)  │
+        │  ─ Cloud Messaging (FCM)   │
+        │  ─ Remote Config           │
+        │  ─ Firestore  (planned)    │
+        │  ─ Auth       (planned)    │
+        │  ─ Functions  (planned)    │
+        └─────────────┬──────────────┘
+                      │
+                      ▼
+        ┌────────────────────────────┐
+        │   Stripe (planned for      │
+        │   invoices & payments)     │
+        └────────────────────────────┘
+```
+
+## 2. Frontend stack
+
+- **React 18** with function components and hooks.
+- **Vite 4** for dev server and production builds. Output: `Worksie/dist/`.
+- **TailwindCSS 3** for styling. No second style system.
+- **react-router-dom v6** with a `createBrowserRouter` config in
+  `Worksie/src/routes.jsx`.
+- **ESLint 8** with the React + React Hooks plugins. `--max-warnings 0`.
+
+## 3. Source layout (current)
+
+```
+Worksie/src/
+├── App.jsx              app shell, mounts router, initializes FCM + RC
+├── main.jsx             React 18 entrypoint
+├── routes.jsx           7 routes: /, /dashboard, /reports, /tasks,
+│                        /crm, /settings, /support
+├── index.css            Tailwind directives
+├── components/          27 UI components, most are 1–5 line stubs
+├── pages/               7 pages (Home, Dashboard, Reports, Tasks,
+│                        CRM, Settings, Support) — all stubs
+└── logic/               firebase.js, remoteConfig.js
+```
+
+There is no `src/hooks/` or `src/context/` despite older docs implying
+otherwise. Add them when there is a real consumer, not before.
+
+## 4. Firebase integration
+
+- **App init** — `Worksie/src/logic/firebase.js` initializes the SDK
+  from `import.meta.env.VITE_FIREBASE_*` values.
+- **Messaging** — `requestForToken()` is called on app mount and asks
+  for a VAPID-keyed FCM token. The VAPID public key is also read from
+  the env (see `Worksie/.env.example`).
+- **Service worker** — `Worksie/public/firebase-messaging-sw.js` runs
+  in a worker context that cannot read Vite env vars. It loads its
+  Firebase config from `firebase-messaging-sw-config.js`, which is
+  **not committed**. See `docs/SECURITY.md`.
+- **Remote Config** — `Worksie/src/logic/remoteConfig.js` fetches and
+  activates Remote Config on app mount and exposes a `getRemoteConfigValue`
+  helper. The defaults seed `promo_banner_enabled`, `promo_banner_text`,
+  and `app_primary_color`. The live values live in
+  `config/worksie-remote-config.json` (uploaded via Firebase API or CLI).
+
+## 5. Data model (planned, not yet implemented)
+
+Worksie does not yet persist any data. The intended Firestore shape is
+informally captured in `Worksie/dataset/worksie_training_schema.jsonl`,
+which seeds the Training Orchestrator agent. A formal Firestore schema
+document will land in this file (or a sibling) once data writes begin.
+
+## 6. Auth model (planned)
+
+- Firebase Auth (email/password to start; OAuth providers later).
+- Roles managed via a `roleManager` module (`AdminHome`, `RoleSelector`
+  components are placeholders for this).
+- Role check happens client-side for UX, server-side via Firestore
+  security rules for correctness. Rules are not yet written.
+
+## 7. Build & deploy flow
+
+1. `npm run build` from `Worksie/` produces `Worksie/dist/`.
+2. `firebase deploy --only hosting` (wrapped by
+   `Worksie/scripts/deploy.sh`) uploads `dist/` according to
+   `Worksie/firebase.json`.
+3. Remote Config changes ship out-of-band via
+   `config/worksie-remote-config.json` + the Firebase API (see
+   `docs/DEPLOYMENT.md`).
+
+## 8. Open design questions
+
+- Where do report PDFs render — in-browser via a JS PDF lib, or via a
+  Cloud Function?
+- Does LiDAR scan processing happen client-side (LiDAR data is large)
+  or off-loaded to a Function / external service?
+- Do we need an "offline mode" for field crews with poor connectivity?
+- Is the CRM its own data domain or shared with Tasks/Reports?
+
+Track answers in `docs/DECISIONS.md`.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,0 +1,125 @@
+# Worksie — Product Requirements Document (PRD)
+
+> Status: **draft v0.1**. This is the first written PRD. It captures
+> intent inferred from the existing scaffold, `Worksie/README.md`, and
+> the four agent prompts in `Worksie/prompts/`. Treat any item not yet
+> in code as a target, not a guarantee.
+
+---
+
+## 1. Problem
+
+Field-services operators (contractors, restoration crews, inspectors,
+roofers, property-services teams) juggle several disconnected tools to
+do one job:
+
+- A camera roll for site photos.
+- A CRM for leads and pipeline.
+- A scheduler for crews.
+- A separate invoicing tool.
+- Email or chat for client updates.
+- Manual PDF assembly for end-of-job reports.
+
+The friction shows up at billing time and in customer trust: photos
+get lost, reports are inconsistent, and follow-up sits in someone's
+inbox.
+
+## 2. Target user
+
+Primary: small-to-mid field-services businesses (1–50 crew members)
+that already use a camera-first tool like CompanyCam, but want CRM,
+payments, and AI reporting in one place.
+
+Secondary: solo operators graduating from a phone-only workflow.
+
+## 3. Goals (what success looks like)
+
+- One app from lead → site visit → documentation → report → invoice.
+- Reports auto-assembled from on-site media, not hand-built.
+- Customers can see live job progress without an extra portal.
+- The product feels like one tool, not a stack of integrations.
+
+## 4. Non-goals (for now)
+
+- Enterprise multi-tenant features (SSO, custom roles beyond a small
+  fixed set).
+- Native mobile applications. The web app must work well on mobile
+  browsers; native is out of scope for v1.
+- Self-hosted deployments. Firebase Hosting is the only target.
+- Marketplace of third-party plugins.
+
+## 5. Feature surfaces
+
+Each feature lists its **current state** vs. **v1 intent**. "Stub"
+means a file exists but contains placeholder JSX.
+
+### 5.1 Capture
+- GPS-tagged photo + video capture (`MediaCapture.jsx`) — *stub*.
+- Annotator on captured media (`Annotator.jsx`) — *stub*.
+- Gallery viewer (`GalleryViewer.jsx`) — *stub*.
+- LiDAR scan ingestion + floorplan auto-gen
+  (`LiDARScanner.jsx`, `FloorplanAutoGen.jsx`, `3DPreview.jsx`) — *stub*.
+
+### 5.2 Reports
+- Auto-report builder (`AutoReportBuilder.jsx`) — *stub*.
+- PDF exporter (`PDFExporter.jsx`) — *stub*.
+- Reports page (`pages/Reports.jsx`) — *stub*.
+
+### 5.3 CRM
+- Lead form, pipeline view, project overview
+  (`CRMLeadForm.jsx`, `PipelineView.jsx`, `ProjectOverview.jsx`) — *stub*.
+- CRM page (`pages/CRM.jsx`) — *stub*.
+
+### 5.4 Scheduling
+- Calendar view (`CalendarView.jsx`) — *stub*.
+- Task board (`TaskBoard.jsx`) — *stub*.
+- Tasks page (`pages/Tasks.jsx`) — *stub*.
+
+### 5.5 Communication
+- Chat window (`ChatWindow.jsx`) — *stub*.
+- Toast notifications (`ToastNotification.jsx`) — *stub*.
+- Firebase Cloud Messaging push wiring — **partial** (`logic/firebase.js`
+  requests a token; no server-side delivery yet).
+
+### 5.6 Payments
+- Invoice builder (`InvoiceBuilder.jsx`) — *stub*.
+- Stripe SDK installed in `package.json`; no flow implemented.
+
+### 5.7 Templates
+- Template marketplace (`TemplateMarket.jsx`) — *stub*.
+- Checklist builder (`ChecklistBuilder.jsx`) — *stub*.
+
+### 5.8 Admin & Auth
+- Login / signup (`LoginForm.jsx`, `SignupForm.jsx`) — *stub*.
+- User profile, avatar upload (`UserProfile.jsx`, `AvatarUpload.jsx`) — *stub*.
+- Role selector, admin home (`RoleSelector.jsx`, `AdminHome.jsx`) — *stub*.
+
+### 5.9 Cross-cutting
+- Firebase Remote Config drives `--primary-color` and the promo banner
+  copy. **Implemented** in `logic/remoteConfig.js`.
+- Support form (`SupportForm.jsx`) — *stub*.
+- Analytics chart (`AnalyticsChart.jsx`) — *stub*.
+
+## 6. Constraints
+
+- Firebase is the chosen backend; do not introduce a competing BaaS.
+- Tailwind is the only styling system; do not introduce a second one.
+- Browser-first; no React Native fork.
+- No real secrets in the repo. See `docs/SECURITY.md`.
+
+## 7. Open questions
+
+- License (MIT? proprietary?). Tracked in `docs/DECISIONS.md`.
+- Whether Firestore is the system of record or only a cache for a
+  separate backend. Currently no Firestore code exists despite README
+  claims.
+- Whether LiDAR scan ingestion is v1-scope or a follow-on.
+- Pricing model and free-tier limits.
+
+## 8. Glossary
+
+- **Stub** — a file that exists in the scaffold but contains only
+  placeholder JSX (typically 1–5 lines).
+- **Surface** — a user-facing feature area (Capture, Reports, CRM, …).
+- **Remote Config** — Firebase Remote Config, used here for runtime
+  theming and feature flagging.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,80 @@
+# Worksie — Roadmap
+
+> Status: **draft v0.1**. Phases are ordered, but dates are deliberately
+> omitted until the team commits to them. Update this file whenever a
+> phase advances.
+
+## Where we are
+
+The repository is **scaffold-stage**. The build pipeline works, lint
+passes, Firebase Hosting is configured, Cloud Messaging requests a
+token on app load, and Remote Config drives a primary color and a
+promo banner. Almost every UI surface is a one-line placeholder.
+
+## Phase 0 — Readiness bootstrap (in progress)
+
+Goal: make the repo safe for long-running agent work and human
+contributors.
+
+- [x] Add `CLAUDE.md` agent guardrails.
+- [x] Add `AGENTS.md` describing the four prompt agents.
+- [x] Add root `README.md` pointing at the nested `Worksie/` app.
+- [x] Add `docs/PRD.md`, `docs/ROADMAP.md`, `docs/DESIGN.md`,
+      `docs/SECURITY.md`, `docs/DEPLOYMENT.md`, `docs/DECISIONS.md`,
+      `docs/CHANGELOG.md`.
+- [x] Add `Worksie/.env.example`.
+- [x] Remove the Firebase service-worker placeholder footgun.
+- [x] Update `.gitignore` for `.env.local`, `*.local`,
+      `.firebase-debug.log`.
+- [x] Refresh `Worksie/docs/worksie_folder_structure.txt` to match
+      reality.
+
+## Phase 1 — Foundations (not started)
+
+Goal: make the scaffold testable and verifiable end-to-end.
+
+- [ ] Pick and install a test runner (Vitest is the obvious fit).
+- [ ] Add a GitHub Actions workflow that runs `npm run lint` and
+      `npm run build` on PRs.
+- [ ] Decide TypeScript: stay on JSX or migrate. Record in
+      `docs/DECISIONS.md`.
+- [ ] Add Firestore wiring (or document explicitly that it is out of
+      scope for v1).
+- [ ] Wire real authentication via Firebase Auth.
+
+## Phase 2 — First vertical slice (not started)
+
+Goal: one feature path actually works end-to-end.
+
+Proposed slice: **Capture → AutoReport**. A logged-in user can take a
+GPS-tagged photo on a job, attach a note, and produce a one-page PDF
+report.
+
+- [ ] Implement `LoginForm.jsx` + `SignupForm.jsx` against Firebase Auth.
+- [ ] Implement `MediaCapture.jsx` with browser camera + geolocation.
+- [ ] Implement `GalleryViewer.jsx`.
+- [ ] Implement `AutoReportBuilder.jsx` + `PDFExporter.jsx`.
+
+## Phase 3 — CRM + tasks (not started)
+
+- [ ] `CRMLeadForm`, `PipelineView`, `ProjectOverview`.
+- [ ] `CalendarView`, `TaskBoard`.
+
+## Phase 4 — Payments (not started)
+
+- [ ] `InvoiceBuilder` with Stripe.
+- [ ] Webhook + Cloud Function for invoice status.
+
+## Phase 5 — Communication + templates (not started)
+
+- [ ] `ChatWindow`, push delivery server.
+- [ ] `TemplateMarket`, `ChecklistBuilder`.
+
+## Known risks
+
+- The four prompt agents in `Worksie/prompts/` are powerful but lack
+  guardrails of their own. Until each phase has guardrails written
+  down, agent output should be human-reviewed.
+- The scaffold contains imports for many features that don't exist
+  yet. Build-time tree-shaking masks this; runtime navigation does
+  not.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,112 @@
+# Worksie — Security & Secrets Policy
+
+> Status: **draft v0.1**. These rules apply to humans and to AI coding
+> agents. Read `CLAUDE.md` for the agent-specific short version.
+
+---
+
+## 1. What must never enter the repo
+
+The following must never be committed in any form (source file,
+fixture, dataset entry, screenshot, log, doc, or commit message):
+
+- Real Firebase web config values that correspond to a non-public /
+  non-throwaway project.
+- Firebase **service-account JSON** files. These are admin credentials.
+- Stripe **secret** keys (`sk_live_…`, `sk_test_…`) or webhook signing
+  secrets.
+- Any `.env`, `.env.local`, or `.env.*.local` file.
+- VAPID **private** keys (the public key may live in env, never the
+  private one).
+- Personal access tokens (GitHub, Firebase CLI tokens, etc.).
+- Customer data of any kind.
+
+`.gitignore` enforces some of this. It is not a substitute for
+attention.
+
+## 2. The Firebase web-config caveat
+
+Firebase's web config values (`apiKey`, `authDomain`, `projectId`,
+`storageBucket`, `messagingSenderId`, `appId`) are **technically public**
+— a determined user can extract them from a deployed app. They are
+not authentication credentials.
+
+That does **not** mean we hard-code them. They still vary by
+environment, and pasting them into the source tree makes it hard to
+switch projects, easy to leak the wrong project's values into the
+wrong build, and easy to confuse them with real secrets later.
+
+**Rule:** Firebase web config values always come from environment
+variables. See `Worksie/.env.example` for the canonical list.
+
+## 3. The service-worker pattern
+
+`Worksie/public/firebase-messaging-sw.js` runs in a service-worker
+context that **cannot read Vite's `import.meta.env`**. Earlier
+versions of this file shipped placeholder strings (`"YOUR_API_KEY"`,
+…) with instructions to hand-edit the file with real values. That is
+the wrong pattern: it actively encourages committing real Firebase
+config to git the moment someone follows the README.
+
+**The current approved pattern is:**
+
+1. `firebase-messaging-sw.js` is committed and imports its config from
+   a sibling file: `public/firebase-messaging-sw-config.js`.
+2. `firebase-messaging-sw-config.js` is **not committed** (it is in
+   `.gitignore`). Developers create it locally from
+   `firebase-messaging-sw-config.example.js`.
+3. The example file ships placeholder values that are obviously fake
+   (`__FIREBASE_API_KEY__`) so accidental commits stand out in code
+   review.
+
+Do not revert this pattern. Do not paste real config into the SW file
+"just for testing" — service-worker files are aggressively cached and
+will outlive the test.
+
+## 4. Stripe
+
+- Only the **publishable** key may appear in the frontend bundle, and
+  even then it comes from an env var.
+- All Stripe secret keys live server-side (planned: Firebase Cloud
+  Functions). No client code should ever reference a Stripe secret
+  key.
+- Webhook signing secrets live in Cloud Functions env, never in repo.
+
+## 5. Push notification keys
+
+- The VAPID **public** key is supplied via `VITE_FIREBASE_VAPID_KEY`.
+- The VAPID **private** key lives in the Firebase project's Cloud
+  Messaging settings. It must never appear in this repository.
+
+## 6. If a secret leaks
+
+1. **Rotate immediately** in the providing console (Firebase, Stripe,
+   Google Cloud).
+2. Remove the value from any future commit.
+3. Treat git history as compromised — `git filter-repo` or a rewrite
+   may be required depending on disclosure.
+4. Document the incident and the rotation in `docs/CHANGELOG.md` under
+   a `### Security` heading for that date.
+
+## 7. Agent-specific rules
+
+(Mirrors `CLAUDE.md` for visibility.)
+
+- Agents must not create `.env`, `.env.local`, or any file containing
+  real keys.
+- Agents must not paste real Firebase config into
+  `firebase-messaging-sw.js`. Use the
+  `firebase-messaging-sw-config.js` pattern documented above.
+- Agents must not run `firebase login` or any command that produces a
+  long-lived CLI token in the repo's working directory.
+- If an agent encounters what looks like a real secret in a file
+  during a task, it must stop and surface the finding to the user
+  rather than silently moving it.
+
+## 8. Reporting a vulnerability
+
+There is no public disclosure inbox yet. Until one exists, file a
+private GitHub Security Advisory on the repository. **Do not** open a
+regular Issue or PR with reproduction details.
+
+Decision tracked in `docs/DECISIONS.md`.


### PR DESCRIPTION
## Summary

Documentation + safety bootstrap so this repo is ready for `/goal` and other long-running agent work. No product features changed; no stubs were implemented.

### Added
- `CLAUDE.md` — agent guardrails (nested `Worksie/` layout, allowed actions, build commands, secrets policy).
- `AGENTS.md` — roster for the four prompt agents in `Worksie/prompts/`.
- Root `README.md` — explains the nested layout and points at `docs/`.
- `docs/PRD.md`, `docs/ROADMAP.md`, `docs/DESIGN.md`, `docs/SECURITY.md`, `docs/DEPLOYMENT.md`, `docs/DECISIONS.md`, `docs/CHANGELOG.md`.
- `Worksie/.env.example` — canonical env-var list for the Firebase web config, VAPID public key, and Stripe publishable key.
- `Worksie/public/firebase-messaging-sw-config.example.js` — template for the new untracked SW config.

### Security fix (the main reason this PR exists)
The previous `Worksie/public/firebase-messaging-sw.js` shipped `YOUR_API_KEY`-style placeholders with README instructions telling users to **hand-edit and commit** real Firebase config. That actively encouraged leaking config into git.

This PR replaces that pattern with a documented import of a gitignored sibling file (`firebase-messaging-sw-config.js`). The SW logs a clear console error if the file is missing instead of silently failing. Rationale in `docs/SECURITY.md` §3 and ADR-005 in `docs/DECISIONS.md`.

### Changed
- `.gitignore` — added `.env.local`, `*.local`, `.firebase-debug.log`, and the local SW config file.
- `Worksie/.gitignore` — added `!.env.example` so the template tracks while `.env.*` stays ignored.
- `Worksie/README.md` — explains nested layout, fixes the broken `.env.example` reference, points at root `docs/`, and flags scaffold/stub status.
- `Worksie/docs/worksie_folder_structure.txt` — replaced with an accurate snapshot (removed references to nonexistent `assets/`, `replit.nix`, `.replit`, `generate_jsonl.py`, `src/hooks/`, `src/context/`).

### Out of scope (deliberately)
- No tests added.
- No CI added.
- No stub components implemented.
- No Firebase rewiring beyond the service-worker safety fix.
- No new secrets, no dependency changes.

## Test plan
- [ ] Reviewer skims `CLAUDE.md` and `AGENTS.md` for accuracy against actual repo state.
- [ ] Reviewer confirms `docs/PRD.md` matches intended product scope.
- [ ] Reviewer confirms `docs/ROADMAP.md` phase ordering.
- [ ] In a clean checkout: `cp Worksie/.env.example Worksie/.env && cp Worksie/public/firebase-messaging-sw-config.example.js Worksie/public/firebase-messaging-sw-config.js`, fill in values, then `cd Worksie && npm install && npm run lint && npm run build` — all should pass.
- [ ] Verify `git status` shows no real env or SW config files after the setup steps above.
- [ ] Confirm `Worksie/.env.example` is tracked but `Worksie/.env` is not.

## Validation that was skipped
`npm run lint` and `npm run build` were not executed in the bootstrap environment — `Worksie/node_modules` was absent and the task instructions said not to install. Reviewer should run both before merge.

https://claude.ai/code/session_01CcMLipZvPdEtsXFqaRBvhf

---
_Generated by [Claude Code](https://claude.ai/code/session_01CcMLipZvPdEtsXFqaRBvhf)_