### PR TITLE
Bootstrap CI: install, lint, build for nested Worksie/ app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  pull_request:
+    paths:
+      - 'Worksie/**'
+      - '.github/workflows/ci.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'Worksie/**'
+      - '.github/workflows/ci.yml'
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Lint & build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: Worksie
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: Worksie/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Summary

Adds the repo's first validation signal — a minimal GitHub Actions workflow that runs `npm ci → npm run lint → npm run build` against the nested `Worksie/` app on every PR and on pushes to `main`.

No tests, no deploy logic, no security scans yet. Just enough to catch broken syntax, broken imports, and broken Vite/Tailwind config before merge. Phase 1 of `docs/ROADMAP.md` (on PR #17) lists Vitest and additional checks as follow-ups.

### Design choices
- **Triggers**: PRs and pushes to `main`, path-filtered to `Worksie/**` and the workflow file itself. Doc-only PRs (like #17) won't burn CI minutes.
- **Working directory**: `Worksie/` via `defaults.run.working-directory` — matches the nested layout documented in PR #17.
- **Node version**: 20 LTS.
- **Cache**: npm cache via `actions/setup-node@v4` with `cache-dependency-path: Worksie/package-lock.json`.
- **Concurrency**: in-progress runs on the same ref are cancelled when a new push lands.
- **Permissions**: `contents: read` only — least-privilege.

### Recommended merge order
1. **PR #17** — readiness bootstrap docs + service-worker safety fix
2. **This PR** — minimal CI
3. Future `/goal` feature work

(This PR could merge first in isolation, but doc readiness gives reviewers context for future CI extensions.)

## Test plan
- [ ] After merge to `main`, open a no-op PR that touches `Worksie/src/App.jsx` and confirm the workflow runs and passes.
- [ ] Open a doc-only PR (touches only `docs/`) and confirm the workflow is **skipped** (path filter working as intended).
- [ ] Locally from `Worksie/`: `npm ci && npm run lint && npm run build` should mirror what CI runs.
- [ ] After PR #17 merges, retrigger this branch (or rebase) and confirm CI still passes with the new files in place.

## Out of scope
- Vitest / test runner.
- Type-check job (project is plain JSX, no TS yet — tracked in `docs/DECISIONS.md` on PR #17).
- Deploy job. `firebase deploy` stays manual until staging exists.
- Security scanning. `docs/SECURITY.md` (on PR #17) plans this for a later phase.
- Dependency updates / Dependabot config.

https://claude.ai/code/session_01CcMLipZvPdEtsXFqaRBvhf

---
_Generated by [Claude Code](https://claude.ai/code/session_01CcMLipZvPdEtsXFqaRBvhf)_