### PR TITLE
feat(db): Phase 2 canonical Drizzle schema for the 21 domain entities

### DIFF
--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -1,12 +1,14 @@
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 
-// Phase 1: minimal client factory. Phase 2 will pass the schema and wire
-// RLS-aware Supabase auth context. The factory takes the connection URL
-// explicitly so the package never reaches into process.env directly.
+import { schema } from "./schema/index";
+
+// Phase 2: client factory wired to the canonical schema so query builders
+// get inferred row/insert types. The factory takes the connection URL
+// explicitly so this package never reaches into process.env directly.
 export function createDbClient(databaseUrl: string) {
   const queryClient = postgres(databaseUrl, { prepare: false });
-  return drizzle(queryClient);
+  return drizzle(queryClient, { schema });
 }
 
 export type DbClient = ReturnType<typeof createDbClient>;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,2 +1,3 @@
-export * as schema from "./schema/index.js";
-export { createDbClient } from "./client.js";
+export * from "./schema/index";
+export { createDbClient } from "./client";
+export type { DbClient } from "./client";

--- a/packages/db/src/schema/enums.ts
+++ b/packages/db/src/schema/enums.ts
@@ -1,0 +1,39 @@
+// Phase 2: PostgreSQL enum types mirrored from @worksie/domain.
+// Domain literal arrays are the source of truth; pgEnum mirrors them into
+// SQL so a domain-level addition shows up as a Drizzle diff and a migration.
+
+import { pgEnum } from "drizzle-orm/pg-core";
+import {
+  CONTRACTOR_DOCUMENT_STATUSES,
+  MEMBERSHIP_ROLES,
+  MEMBERSHIP_STATUSES,
+  PAYOUT_PERIOD_STATUSES,
+  PAYOUT_RULE_MODES,
+  PROOF_OF_WORK_KINDS,
+  WORK_ORDER_EVENT_SOURCES,
+  WORK_ORDER_STATES
+} from "@worksie/domain";
+
+export const workOrderStateEnum = pgEnum("work_order_state", WORK_ORDER_STATES);
+export const workOrderEventSourceEnum = pgEnum(
+  "work_order_event_source",
+  WORK_ORDER_EVENT_SOURCES
+);
+export const membershipRoleEnum = pgEnum("membership_role", MEMBERSHIP_ROLES);
+export const membershipStatusEnum = pgEnum(
+  "membership_status",
+  MEMBERSHIP_STATUSES
+);
+export const contractorDocumentStatusEnum = pgEnum(
+  "contractor_document_status",
+  CONTRACTOR_DOCUMENT_STATUSES
+);
+export const payoutRuleModeEnum = pgEnum("payout_rule_mode", PAYOUT_RULE_MODES);
+export const payoutPeriodStatusEnum = pgEnum(
+  "payout_period_status",
+  PAYOUT_PERIOD_STATUSES
+);
+export const proofOfWorkKindEnum = pgEnum(
+  "proof_of_work_kind",
+  PROOF_OF_WORK_KINDS
+);

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -1,11 +1,53 @@
-// Phase 1: placeholder schema. No tables defined yet.
-// Phase 2 lands the canonical schema derived from docs/DOMAIN_MODEL.md:
-// tenants, users, memberships, business_profiles, service_definitions
-// (including customer_signoff_required), document_types,
-// contractor_documents, safety_packs, safety_acknowledgements,
-// work_orders, work_order_line_items, work_order_events,
-// checklist_templates, checklist_instances, checklist_steps,
-// proof_of_work_artifacts, customers, customer_signoffs,
-// payout_rules, payout_periods, payout_lines.
-// Every table carries tenant_id and is RLS-gated on it.
-export const schema = {} as const;
+// Canonical Worksie schema — 21 entities from docs/DOMAIN_MODEL.md.
+// Source of truth for Drizzle, drizzle-kit, and the Supabase migration pipeline.
+
+export * from "./enums";
+export * from "./tables";
+
+import {
+  businessProfiles,
+  checklistInstances,
+  checklistSteps,
+  checklistTemplates,
+  contractorDocuments,
+  customerSignoffs,
+  customers,
+  documentTypes,
+  memberships,
+  payoutLines,
+  payoutPeriods,
+  payoutRules,
+  proofOfWorkArtifacts,
+  safetyAcknowledgements,
+  safetyPacks,
+  serviceDefinitions,
+  tenants,
+  users,
+  workOrderEvents,
+  workOrderLineItems,
+  workOrders
+} from "./tables";
+
+export const schema = {
+  tenants,
+  users,
+  memberships,
+  businessProfiles,
+  serviceDefinitions,
+  documentTypes,
+  contractorDocuments,
+  safetyPacks,
+  safetyAcknowledgements,
+  workOrders,
+  workOrderLineItems,
+  workOrderEvents,
+  checklistTemplates,
+  checklistInstances,
+  checklistSteps,
+  proofOfWorkArtifacts,
+  customers,
+  customerSignoffs,
+  payoutRules,
+  payoutPeriods,
+  payoutLines
+} as const;

--- a/packages/db/src/schema/tables.ts
+++ b/packages/db/src/schema/tables.ts
@@ -1,0 +1,570 @@
+// Phase 2: canonical Drizzle schema for the 21 entities defined in
+// docs/DOMAIN_MODEL.md. Every row carries `tenant_id`; RLS policies and the
+// work_order_events append-only trigger live in the companion SQL migration.
+//
+// Hard rules enforced here (DB level):
+//   - tenant_id is NOT NULL everywhere.
+//   - work_orders.service_snapshot_json is NOT NULL (frozen at creation).
+//   - work_order_events.reason is required when to_state ∈ {cancelled, voided}.
+// Rules enforced in code (Phase 3+):
+//   - Compliance gate (gating documents + safety acks).
+//   - Work-order lifecycle transitions (see docs/WORK_ORDER_LIFECYCLE.md).
+//   - Payout-line append-only inside an approved period.
+
+import { sql } from "drizzle-orm";
+import {
+  boolean,
+  check,
+  index,
+  integer,
+  jsonb,
+  numeric,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid
+} from "drizzle-orm/pg-core";
+
+import {
+  contractorDocumentStatusEnum,
+  membershipRoleEnum,
+  membershipStatusEnum,
+  payoutPeriodStatusEnum,
+  payoutRuleModeEnum,
+  proofOfWorkKindEnum,
+  workOrderEventSourceEnum,
+  workOrderStateEnum
+} from "./enums";
+
+// 1. Tenant — top-level isolation container.
+export const tenants = pgTable("tenants", {
+  id: uuid().primaryKey().defaultRandom(),
+  name: text().notNull(),
+  timezone: text().notNull(),
+  defaultPayoutPeriod: text().notNull().default("weekly_mon_sun"),
+  createdAt: timestamp({ withTimezone: true }).notNull().defaultNow()
+});
+
+// 2. User — human with login credentials, 1:1 with Supabase auth.users.
+export const users = pgTable(
+  "users",
+  {
+    id: uuid().primaryKey().defaultRandom(),
+    authUserId: uuid().notNull(),
+    email: text().notNull(),
+    displayName: text(),
+    phone: text(),
+    createdAt: timestamp({ withTimezone: true }).notNull().defaultNow()
+  },
+  (t) => [
+    uniqueIndex("users_auth_user_id_unique").on(t.authUserId),
+    uniqueIndex("users_email_lower_unique").on(sql`lower(${t.email})`)
+  ]
+);
+
+// 3. Membership — join between User and Tenant carrying a role.
+export const memberships = pgTable(
+  "memberships",
+  {
+    id: uuid().primaryKey().defaultRandom(),
+    tenantId: uuid()
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    userId: uuid()
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    role: membershipRoleEnum().notNull(),
+    status: membershipStatusEnum().notNull().default("invited"),
+    createdAt: timestamp({ withTimezone: true }).notNull().defaultNow()
+  },
+  (t) => [
+    uniqueIndex("memberships_tenant_user_unique").on(t.tenantId, t.userId),
+    index("memberships_tenant_idx").on(t.tenantId),
+    index("memberships_user_idx").on(t.userId)
+  ]
+);
+
+// 4. Safety Pack — bundle of safety acknowledgements (referenced by
+// business profiles and service definitions).
+export const safetyPacks = pgTable(
+  "safety_packs",
+  {
+    id: uuid().primaryKey().defaultRandom(),
+    tenantId: uuid()
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    name: text().notNull(),
+    version: integer().notNull().default(1),
+    contentRef: text(),
+    createdAt: timestamp({ withTimezone: true }).notNull().defaultNow()
+  },
+  (t) => [
+    index("safety_packs_tenant_idx").on(t.tenantId),
+    uniqueIndex("safety_packs_tenant_name_version_unique").on(
+      t.tenantId,
+      t.name,
+      t.version
+    )
+  ]
+);
+
+// 5. Business Profile — operating business inside a tenant.
+export const businessProfiles = pgTable(
+  "business_profiles",
+  {
+    id: uuid().primaryKey().defaultRandom(),
+    tenantId: uuid()
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    legalName: text().notNull(),
+    dba: text(),
+    jurisdictions: jsonb()
+      .$type<string[]>()
+      .notNull()
+      .default(sql`'[]'::jsonb`),
+    defaultSafetyPackId: uuid().references(() => safetyPacks.id, {
+      onDelete: "set null"
+    }),
+    createdAt: timestamp({ withTimezone: true }).notNull().defaultNow()
+  },
+  (t) => [index("business_profiles_tenant_idx").on(t.tenantId)]
+);
+
+// 6. Document Type — required compliance artifact definition.
+export const documentTypes = pgTable(
+  "document_types",
+  {
+    id: uuid().primaryKey().defaultRandom(),
+    tenantId: uuid()
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    name: text().notNull(),
+    appliesTo: text().notNull(),
+    expirable: boolean().notNull().default(false),
+    gating: boolean().notNull().default(false),
+    createdAt: timestamp({ withTimezone: true }).notNull().defaultNow()
+  },
+  (t) => [
+    index("document_types_tenant_idx").on(t.tenantId),
+    uniqueIndex("document_types_tenant_name_unique").on(t.tenantId, t.name),
+    check(
+      "document_types_applies_to_check",
+      sql`${t.appliesTo} IN ('contractor', 'business', 'vehicle')`
+    )
+  ]
+);
+
+// 7. Payout Rule — selects mode + rate table (referenced by service
+// definitions and frozen onto work orders via service_snapshot_json).
+export const payoutRules = pgTable(
+  "payout_rules",
+  {
+    id: uuid().primaryKey().defaultRandom(),
+    tenantId: uuid()
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    name: text().notNull(),
+    mode: payoutRuleModeEnum().notNull(),
+    rateTableJson: jsonb()
+      .$type<Record<string, unknown>>()
+      .notNull()
+      .default(sql`'{}'::jsonb`),
+    createdAt: timestamp({ withTimezone: true }).notNull().defaultNow()
+  },
+  (t) => [
+    index("payout_rules_tenant_idx").on(t.tenantId),
+    uniqueIndex("payout_rules_tenant_name_unique").on(t.tenantId, t.name)
+  ]
+);
+
+// 8. Checklist Template — ordered list of steps (stored inline as JSON;
+// concrete per-work-order steps live on checklist_steps).
+export const checklistTemplates = pgTable(
+  "checklist_templates",
+  {
+    id: uuid().primaryKey().defaultRandom(),
+    tenantId: uuid()
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    name: text().notNull(),
+    stepsJson: jsonb()
+      .$type<
+        Array<{
+          label: string;
+          ordinal: number;
+          requiresPhoto: boolean;
+          requiresSignature: boolean;
+        }>
+      >()
+      .notNull()
+      .default(sql`'[]'::jsonb`),
+    createdAt: timestamp({ withTimezone: true }).notNull().defaultNow()
+  },
+  (t) => [index("checklist_templates_tenant_idx").on(t.tenantId)]
+);
+
+// 9. Service Definition — what the business is capable of performing.
+export const serviceDefinitions = pgTable(
+  "service_definitions",
+  {
+    id: uuid().primaryKey().defaultRandom(),
+    tenantId: uuid()
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    name: text().notNull(),
+    category: text().notNull(),
+    defaultPayoutRuleId: uuid().references(() => payoutRules.id, {
+      onDelete: "set null"
+    }),
+    checklistTemplateId: uuid().references(() => checklistTemplates.id, {
+      onDelete: "set null"
+    }),
+    requiredGear: jsonb()
+      .$type<string[]>()
+      .notNull()
+      .default(sql`'[]'::jsonb`),
+    requiredDocuments: jsonb()
+      .$type<string[]>()
+      .notNull()
+      .default(sql`'[]'::jsonb`),
+    requiredSafetySteps: jsonb()
+      .$type<string[]>()
+      .notNull()
+      .default(sql`'[]'::jsonb`),
+    customerSignoffRequired: boolean().notNull().default(false),
+    createdAt: timestamp({ withTimezone: true }).notNull().defaultNow()
+  },
+  (t) => [
+    index("service_definitions_tenant_idx").on(t.tenantId),
+    uniqueIndex("service_definitions_tenant_name_unique").on(t.tenantId, t.name)
+  ]
+);
+
+// 10. Customer — light-touch in v1 (no account, no login).
+export const customers = pgTable(
+  "customers",
+  {
+    id: uuid().primaryKey().defaultRandom(),
+    tenantId: uuid()
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    name: text().notNull(),
+    phone: text(),
+    email: text(),
+    address: text(),
+    createdAt: timestamp({ withTimezone: true }).notNull().defaultNow()
+  },
+  (t) => [index("customers_tenant_idx").on(t.tenantId)]
+);
+
+// 11. Work Order — concrete instance of a service for a customer.
+export const workOrders = pgTable(
+  "work_orders",
+  {
+    id: uuid().primaryKey().defaultRandom(),
+    tenantId: uuid()
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    serviceDefinitionId: uuid()
+      .notNull()
+      .references(() => serviceDefinitions.id, { onDelete: "restrict" }),
+    serviceSnapshotJson: jsonb()
+      .$type<Record<string, unknown>>()
+      .notNull(),
+    customerId: uuid()
+      .notNull()
+      .references(() => customers.id, { onDelete: "restrict" }),
+    address: text(),
+    gps: jsonb().$type<{ lat: number; lng: number }>(),
+    scheduledFor: timestamp({ withTimezone: true }),
+    assignedContractorMembershipId: uuid().references(() => memberships.id, {
+      onDelete: "set null"
+    }),
+    status: workOrderStateEnum().notNull().default("draft"),
+    createdAt: timestamp({ withTimezone: true }).notNull().defaultNow(),
+    createdBy: uuid().references(() => users.id, { onDelete: "set null" })
+  },
+  (t) => [
+    index("work_orders_tenant_idx").on(t.tenantId),
+    index("work_orders_tenant_status_idx").on(t.tenantId, t.status),
+    index("work_orders_service_idx").on(t.serviceDefinitionId),
+    index("work_orders_customer_idx").on(t.customerId),
+    index("work_orders_assigned_contractor_idx").on(
+      t.assignedContractorMembershipId
+    )
+  ]
+);
+
+// 12. Work Order Line Item — drives piece-rate payout.
+export const workOrderLineItems = pgTable(
+  "work_order_line_items",
+  {
+    id: uuid().primaryKey().defaultRandom(),
+    tenantId: uuid()
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    workOrderId: uuid()
+      .notNull()
+      .references(() => workOrders.id, { onDelete: "cascade" }),
+    description: text().notNull(),
+    quantity: numeric({ precision: 12, scale: 3 }).notNull().default("1"),
+    unit: text().notNull().default("each"),
+    pieceRateAmount: numeric({ precision: 12, scale: 2 }),
+    completedAt: timestamp({ withTimezone: true }),
+    createdAt: timestamp({ withTimezone: true }).notNull().defaultNow()
+  },
+  (t) => [
+    index("work_order_line_items_tenant_idx").on(t.tenantId),
+    index("work_order_line_items_work_order_idx").on(t.workOrderId)
+  ]
+);
+
+// 13. Work Order Event — immutable audit row per state transition.
+// Append-only is enforced by trigger in the companion SQL migration.
+export const workOrderEvents = pgTable(
+  "work_order_events",
+  {
+    id: uuid().primaryKey().defaultRandom(),
+    tenantId: uuid()
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    workOrderId: uuid()
+      .notNull()
+      .references(() => workOrders.id, { onDelete: "cascade" }),
+    fromState: workOrderStateEnum(),
+    toState: workOrderStateEnum().notNull(),
+    actor: uuid().references(() => users.id, { onDelete: "set null" }),
+    at: timestamp({ withTimezone: true }).notNull().defaultNow(),
+    reason: text(),
+    source: workOrderEventSourceEnum().notNull()
+  },
+  (t) => [
+    index("work_order_events_tenant_idx").on(t.tenantId),
+    index("work_order_events_work_order_at_idx").on(t.workOrderId, t.at),
+    check(
+      "work_order_events_cancelled_voided_needs_reason",
+      sql`${t.toState} NOT IN ('cancelled', 'voided') OR (${t.reason} IS NOT NULL AND length(btrim(${t.reason})) > 0)`
+    )
+  ]
+);
+
+// 14. Checklist Instance — bound to a work order.
+export const checklistInstances = pgTable(
+  "checklist_instances",
+  {
+    id: uuid().primaryKey().defaultRandom(),
+    tenantId: uuid()
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    workOrderId: uuid()
+      .notNull()
+      .references(() => workOrders.id, { onDelete: "cascade" }),
+    checklistTemplateId: uuid()
+      .notNull()
+      .references(() => checklistTemplates.id, { onDelete: "restrict" }),
+    createdAt: timestamp({ withTimezone: true }).notNull().defaultNow()
+  },
+  (t) => [
+    index("checklist_instances_tenant_idx").on(t.tenantId),
+    uniqueIndex("checklist_instances_work_order_unique").on(t.workOrderId)
+  ]
+);
+
+// 15. Checklist Step — per-instance step with completion + photo flags.
+export const checklistSteps = pgTable(
+  "checklist_steps",
+  {
+    id: uuid().primaryKey().defaultRandom(),
+    tenantId: uuid()
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    checklistInstanceId: uuid()
+      .notNull()
+      .references(() => checklistInstances.id, { onDelete: "cascade" }),
+    ordinal: integer().notNull(),
+    label: text().notNull(),
+    requiresPhoto: boolean().notNull().default(false),
+    requiresSignature: boolean().notNull().default(false),
+    completedAt: timestamp({ withTimezone: true }),
+    completedBy: uuid().references(() => users.id, { onDelete: "set null" })
+  },
+  (t) => [
+    index("checklist_steps_tenant_idx").on(t.tenantId),
+    index("checklist_steps_instance_ordinal_idx").on(
+      t.checklistInstanceId,
+      t.ordinal
+    )
+  ]
+);
+
+// 16. Proof-of-Work Artifact — photos, signatures, PDFs, notes.
+export const proofOfWorkArtifacts = pgTable(
+  "proof_of_work_artifacts",
+  {
+    id: uuid().primaryKey().defaultRandom(),
+    tenantId: uuid()
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    workOrderId: uuid()
+      .notNull()
+      .references(() => workOrders.id, { onDelete: "cascade" }),
+    checklistStepId: uuid().references(() => checklistSteps.id, {
+      onDelete: "set null"
+    }),
+    kind: proofOfWorkKindEnum().notNull(),
+    fileId: text(),
+    localFileUri: text(),
+    gps: jsonb().$type<{ lat: number; lng: number }>(),
+    capturedAt: timestamp({ withTimezone: true }).notNull(),
+    capturedBy: uuid().references(() => users.id, { onDelete: "set null" }),
+    createdAt: timestamp({ withTimezone: true }).notNull().defaultNow()
+  },
+  (t) => [
+    index("proof_of_work_artifacts_tenant_idx").on(t.tenantId),
+    index("proof_of_work_artifacts_work_order_idx").on(t.workOrderId),
+    index("proof_of_work_artifacts_step_idx").on(t.checklistStepId)
+  ]
+);
+
+// 17. Customer Sign-off — captured at work-order completion if the service
+// definition requires it.
+export const customerSignoffs = pgTable(
+  "customer_signoffs",
+  {
+    id: uuid().primaryKey().defaultRandom(),
+    tenantId: uuid()
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    workOrderId: uuid()
+      .notNull()
+      .references(() => workOrders.id, { onDelete: "cascade" }),
+    signedAt: timestamp({ withTimezone: true }).notNull(),
+    signatureFileId: text().notNull(),
+    signedName: text().notNull(),
+    createdAt: timestamp({ withTimezone: true }).notNull().defaultNow()
+  },
+  (t) => [
+    index("customer_signoffs_tenant_idx").on(t.tenantId),
+    uniqueIndex("customer_signoffs_work_order_unique").on(t.workOrderId)
+  ]
+);
+
+// 18. Contractor Document — submitted instance of a Document Type.
+export const contractorDocuments = pgTable(
+  "contractor_documents",
+  {
+    id: uuid().primaryKey().defaultRandom(),
+    tenantId: uuid()
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    contractorMembershipId: uuid()
+      .notNull()
+      .references(() => memberships.id, { onDelete: "cascade" }),
+    documentTypeId: uuid()
+      .notNull()
+      .references(() => documentTypes.id, { onDelete: "restrict" }),
+    fileId: text(),
+    issuedOn: timestamp({ withTimezone: true }),
+    expiresOn: timestamp({ withTimezone: true }),
+    verifiedBy: uuid().references(() => users.id, { onDelete: "set null" }),
+    verifiedAt: timestamp({ withTimezone: true }),
+    status: contractorDocumentStatusEnum().notNull().default("pending"),
+    createdAt: timestamp({ withTimezone: true }).notNull().defaultNow()
+  },
+  (t) => [
+    index("contractor_documents_tenant_idx").on(t.tenantId),
+    index("contractor_documents_contractor_idx").on(t.contractorMembershipId),
+    index("contractor_documents_type_idx").on(t.documentTypeId),
+    index("contractor_documents_expires_idx").on(t.expiresOn)
+  ]
+);
+
+// 19. Safety Acknowledgement — signed acknowledgement by a contractor.
+export const safetyAcknowledgements = pgTable(
+  "safety_acknowledgements",
+  {
+    id: uuid().primaryKey().defaultRandom(),
+    tenantId: uuid()
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    contractorMembershipId: uuid()
+      .notNull()
+      .references(() => memberships.id, { onDelete: "cascade" }),
+    safetyPackId: uuid()
+      .notNull()
+      .references(() => safetyPacks.id, { onDelete: "restrict" }),
+    signedAt: timestamp({ withTimezone: true }).notNull(),
+    signatureFileId: text(),
+    createdAt: timestamp({ withTimezone: true }).notNull().defaultNow()
+  },
+  (t) => [
+    index("safety_acknowledgements_tenant_idx").on(t.tenantId),
+    index("safety_acknowledgements_contractor_idx").on(t.contractorMembershipId),
+    index("safety_acknowledgements_pack_idx").on(t.safetyPackId),
+    uniqueIndex("safety_acknowledgements_contractor_pack_unique").on(
+      t.contractorMembershipId,
+      t.safetyPackId
+    )
+  ]
+);
+
+// 20. Payout Period — weekly Mon–Sun by default; status flow open → draft →
+// approved → paid.
+export const payoutPeriods = pgTable(
+  "payout_periods",
+  {
+    id: uuid().primaryKey().defaultRandom(),
+    tenantId: uuid()
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    periodStart: timestamp({ withTimezone: true }).notNull(),
+    periodEnd: timestamp({ withTimezone: true }).notNull(),
+    cutoffAt: timestamp({ withTimezone: true }).notNull(),
+    paidOn: timestamp({ withTimezone: true }),
+    status: payoutPeriodStatusEnum().notNull().default("open"),
+    createdAt: timestamp({ withTimezone: true }).notNull().defaultNow()
+  },
+  (t) => [
+    index("payout_periods_tenant_idx").on(t.tenantId),
+    uniqueIndex("payout_periods_tenant_range_unique").on(
+      t.tenantId,
+      t.periodStart,
+      t.periodEnd
+    )
+  ]
+);
+
+// 21. Payout Line — one row per (period, contractor, work order [, line item]).
+export const payoutLines = pgTable(
+  "payout_lines",
+  {
+    id: uuid().primaryKey().defaultRandom(),
+    tenantId: uuid()
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    payoutPeriodId: uuid()
+      .notNull()
+      .references(() => payoutPeriods.id, { onDelete: "cascade" }),
+    contractorMembershipId: uuid()
+      .notNull()
+      .references(() => memberships.id, { onDelete: "restrict" }),
+    workOrderId: uuid()
+      .notNull()
+      .references(() => workOrders.id, { onDelete: "restrict" }),
+    workOrderLineItemId: uuid().references(() => workOrderLineItems.id, {
+      onDelete: "set null"
+    }),
+    amount: numeric({ precision: 14, scale: 2 }).notNull(),
+    computedFrom: uuid().references(() => payoutRules.id, {
+      onDelete: "set null"
+    }),
+    createdAt: timestamp({ withTimezone: true }).notNull().defaultNow()
+  },
+  (t) => [
+    index("payout_lines_tenant_idx").on(t.tenantId),
+    index("payout_lines_period_idx").on(t.payoutPeriodId),
+    index("payout_lines_contractor_idx").on(t.contractorMembershipId),
+    index("payout_lines_work_order_idx").on(t.workOrderId)
+  ]
+);

--- a/supabase/migrations/0000_phase_2_canonical_schema.sql
+++ b/supabase/migrations/0000_phase_2_canonical_schema.sql
@@ -1,0 +1,572 @@
+CREATE TYPE "public"."contractor_document_status" AS ENUM('pending', 'verified', 'rejected', 'expired');--> statement-breakpoint
+CREATE TYPE "public"."membership_role" AS ENUM('operator', 'back_office', 'contractor', 'customer');--> statement-breakpoint
+CREATE TYPE "public"."membership_status" AS ENUM('invited', 'active', 'suspended');--> statement-breakpoint
+CREATE TYPE "public"."payout_period_status" AS ENUM('open', 'draft', 'approved', 'paid');--> statement-breakpoint
+CREATE TYPE "public"."payout_rule_mode" AS ENUM('piece_rate', 'completion_flat', 'hourly_capped');--> statement-breakpoint
+CREATE TYPE "public"."proof_of_work_kind" AS ENUM('photo', 'video', 'signature', 'pdf', 'note');--> statement-breakpoint
+CREATE TYPE "public"."work_order_event_source" AS ENUM('web_admin', 'mobile', 'system');--> statement-breakpoint
+CREATE TYPE "public"."work_order_state" AS ENUM('draft', 'scheduled', 'dispatched', 'in_progress', 'awaiting_signoff', 'completed', 'invoiced', 'paid_out', 'cancelled', 'voided');--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "business_profiles" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"legal_name" text NOT NULL,
+	"dba" text,
+	"jurisdictions" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"default_safety_pack_id" uuid,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "checklist_instances" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"work_order_id" uuid NOT NULL,
+	"checklist_template_id" uuid NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "checklist_steps" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"checklist_instance_id" uuid NOT NULL,
+	"ordinal" integer NOT NULL,
+	"label" text NOT NULL,
+	"requires_photo" boolean DEFAULT false NOT NULL,
+	"requires_signature" boolean DEFAULT false NOT NULL,
+	"completed_at" timestamp with time zone,
+	"completed_by" uuid
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "checklist_templates" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"name" text NOT NULL,
+	"steps_json" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "contractor_documents" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"contractor_membership_id" uuid NOT NULL,
+	"document_type_id" uuid NOT NULL,
+	"file_id" text,
+	"issued_on" timestamp with time zone,
+	"expires_on" timestamp with time zone,
+	"verified_by" uuid,
+	"verified_at" timestamp with time zone,
+	"status" "contractor_document_status" DEFAULT 'pending' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "customer_signoffs" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"work_order_id" uuid NOT NULL,
+	"signed_at" timestamp with time zone NOT NULL,
+	"signature_file_id" text NOT NULL,
+	"signed_name" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "customers" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"name" text NOT NULL,
+	"phone" text,
+	"email" text,
+	"address" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "document_types" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"name" text NOT NULL,
+	"applies_to" text NOT NULL,
+	"expirable" boolean DEFAULT false NOT NULL,
+	"gating" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "document_types_applies_to_check" CHECK ("document_types"."applies_to" IN ('contractor', 'business', 'vehicle'))
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "memberships" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"user_id" uuid NOT NULL,
+	"role" "membership_role" NOT NULL,
+	"status" "membership_status" DEFAULT 'invited' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "payout_lines" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"payout_period_id" uuid NOT NULL,
+	"contractor_membership_id" uuid NOT NULL,
+	"work_order_id" uuid NOT NULL,
+	"work_order_line_item_id" uuid,
+	"amount" numeric(14, 2) NOT NULL,
+	"computed_from" uuid,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "payout_periods" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"period_start" timestamp with time zone NOT NULL,
+	"period_end" timestamp with time zone NOT NULL,
+	"cutoff_at" timestamp with time zone NOT NULL,
+	"paid_on" timestamp with time zone,
+	"status" "payout_period_status" DEFAULT 'open' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "payout_rules" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"name" text NOT NULL,
+	"mode" "payout_rule_mode" NOT NULL,
+	"rate_table_json" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "proof_of_work_artifacts" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"work_order_id" uuid NOT NULL,
+	"checklist_step_id" uuid,
+	"kind" "proof_of_work_kind" NOT NULL,
+	"file_id" text,
+	"local_file_uri" text,
+	"gps" jsonb,
+	"captured_at" timestamp with time zone NOT NULL,
+	"captured_by" uuid,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "safety_acknowledgements" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"contractor_membership_id" uuid NOT NULL,
+	"safety_pack_id" uuid NOT NULL,
+	"signed_at" timestamp with time zone NOT NULL,
+	"signature_file_id" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "safety_packs" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"name" text NOT NULL,
+	"version" integer DEFAULT 1 NOT NULL,
+	"content_ref" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "service_definitions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"name" text NOT NULL,
+	"category" text NOT NULL,
+	"default_payout_rule_id" uuid,
+	"checklist_template_id" uuid,
+	"required_gear" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"required_documents" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"required_safety_steps" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"customer_signoff_required" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "tenants" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"timezone" text NOT NULL,
+	"default_payout_period" text DEFAULT 'weekly_mon_sun' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "users" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"auth_user_id" uuid NOT NULL,
+	"email" text NOT NULL,
+	"display_name" text,
+	"phone" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "work_order_events" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"work_order_id" uuid NOT NULL,
+	"from_state" "work_order_state",
+	"to_state" "work_order_state" NOT NULL,
+	"actor" uuid,
+	"at" timestamp with time zone DEFAULT now() NOT NULL,
+	"reason" text,
+	"source" "work_order_event_source" NOT NULL,
+	CONSTRAINT "work_order_events_cancelled_voided_needs_reason" CHECK ("work_order_events"."to_state" NOT IN ('cancelled', 'voided') OR ("work_order_events"."reason" IS NOT NULL AND length(btrim("work_order_events"."reason")) > 0))
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "work_order_line_items" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"work_order_id" uuid NOT NULL,
+	"description" text NOT NULL,
+	"quantity" numeric(12, 3) DEFAULT '1' NOT NULL,
+	"unit" text DEFAULT 'each' NOT NULL,
+	"piece_rate_amount" numeric(12, 2),
+	"completed_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "work_orders" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"service_definition_id" uuid NOT NULL,
+	"service_snapshot_json" jsonb NOT NULL,
+	"customer_id" uuid NOT NULL,
+	"address" text,
+	"gps" jsonb,
+	"scheduled_for" timestamp with time zone,
+	"assigned_contractor_membership_id" uuid,
+	"status" "work_order_state" DEFAULT 'draft' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"created_by" uuid
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "business_profiles" ADD CONSTRAINT "business_profiles_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "business_profiles" ADD CONSTRAINT "business_profiles_default_safety_pack_id_safety_packs_id_fk" FOREIGN KEY ("default_safety_pack_id") REFERENCES "public"."safety_packs"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "checklist_instances" ADD CONSTRAINT "checklist_instances_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "checklist_instances" ADD CONSTRAINT "checklist_instances_work_order_id_work_orders_id_fk" FOREIGN KEY ("work_order_id") REFERENCES "public"."work_orders"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "checklist_instances" ADD CONSTRAINT "checklist_instances_checklist_template_id_checklist_templates_id_fk" FOREIGN KEY ("checklist_template_id") REFERENCES "public"."checklist_templates"("id") ON DELETE restrict ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "checklist_steps" ADD CONSTRAINT "checklist_steps_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "checklist_steps" ADD CONSTRAINT "checklist_steps_checklist_instance_id_checklist_instances_id_fk" FOREIGN KEY ("checklist_instance_id") REFERENCES "public"."checklist_instances"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "checklist_steps" ADD CONSTRAINT "checklist_steps_completed_by_users_id_fk" FOREIGN KEY ("completed_by") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "checklist_templates" ADD CONSTRAINT "checklist_templates_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "contractor_documents" ADD CONSTRAINT "contractor_documents_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "contractor_documents" ADD CONSTRAINT "contractor_documents_contractor_membership_id_memberships_id_fk" FOREIGN KEY ("contractor_membership_id") REFERENCES "public"."memberships"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "contractor_documents" ADD CONSTRAINT "contractor_documents_document_type_id_document_types_id_fk" FOREIGN KEY ("document_type_id") REFERENCES "public"."document_types"("id") ON DELETE restrict ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "contractor_documents" ADD CONSTRAINT "contractor_documents_verified_by_users_id_fk" FOREIGN KEY ("verified_by") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "customer_signoffs" ADD CONSTRAINT "customer_signoffs_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "customer_signoffs" ADD CONSTRAINT "customer_signoffs_work_order_id_work_orders_id_fk" FOREIGN KEY ("work_order_id") REFERENCES "public"."work_orders"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "customers" ADD CONSTRAINT "customers_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "document_types" ADD CONSTRAINT "document_types_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "memberships" ADD CONSTRAINT "memberships_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "memberships" ADD CONSTRAINT "memberships_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "payout_lines" ADD CONSTRAINT "payout_lines_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "payout_lines" ADD CONSTRAINT "payout_lines_payout_period_id_payout_periods_id_fk" FOREIGN KEY ("payout_period_id") REFERENCES "public"."payout_periods"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "payout_lines" ADD CONSTRAINT "payout_lines_contractor_membership_id_memberships_id_fk" FOREIGN KEY ("contractor_membership_id") REFERENCES "public"."memberships"("id") ON DELETE restrict ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "payout_lines" ADD CONSTRAINT "payout_lines_work_order_id_work_orders_id_fk" FOREIGN KEY ("work_order_id") REFERENCES "public"."work_orders"("id") ON DELETE restrict ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "payout_lines" ADD CONSTRAINT "payout_lines_work_order_line_item_id_work_order_line_items_id_fk" FOREIGN KEY ("work_order_line_item_id") REFERENCES "public"."work_order_line_items"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "payout_lines" ADD CONSTRAINT "payout_lines_computed_from_payout_rules_id_fk" FOREIGN KEY ("computed_from") REFERENCES "public"."payout_rules"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "payout_periods" ADD CONSTRAINT "payout_periods_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "payout_rules" ADD CONSTRAINT "payout_rules_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "proof_of_work_artifacts" ADD CONSTRAINT "proof_of_work_artifacts_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "proof_of_work_artifacts" ADD CONSTRAINT "proof_of_work_artifacts_work_order_id_work_orders_id_fk" FOREIGN KEY ("work_order_id") REFERENCES "public"."work_orders"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "proof_of_work_artifacts" ADD CONSTRAINT "proof_of_work_artifacts_checklist_step_id_checklist_steps_id_fk" FOREIGN KEY ("checklist_step_id") REFERENCES "public"."checklist_steps"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "proof_of_work_artifacts" ADD CONSTRAINT "proof_of_work_artifacts_captured_by_users_id_fk" FOREIGN KEY ("captured_by") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "safety_acknowledgements" ADD CONSTRAINT "safety_acknowledgements_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "safety_acknowledgements" ADD CONSTRAINT "safety_acknowledgements_contractor_membership_id_memberships_id_fk" FOREIGN KEY ("contractor_membership_id") REFERENCES "public"."memberships"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "safety_acknowledgements" ADD CONSTRAINT "safety_acknowledgements_safety_pack_id_safety_packs_id_fk" FOREIGN KEY ("safety_pack_id") REFERENCES "public"."safety_packs"("id") ON DELETE restrict ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "safety_packs" ADD CONSTRAINT "safety_packs_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "service_definitions" ADD CONSTRAINT "service_definitions_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "service_definitions" ADD CONSTRAINT "service_definitions_default_payout_rule_id_payout_rules_id_fk" FOREIGN KEY ("default_payout_rule_id") REFERENCES "public"."payout_rules"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "service_definitions" ADD CONSTRAINT "service_definitions_checklist_template_id_checklist_templates_id_fk" FOREIGN KEY ("checklist_template_id") REFERENCES "public"."checklist_templates"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "work_order_events" ADD CONSTRAINT "work_order_events_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "work_order_events" ADD CONSTRAINT "work_order_events_work_order_id_work_orders_id_fk" FOREIGN KEY ("work_order_id") REFERENCES "public"."work_orders"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "work_order_events" ADD CONSTRAINT "work_order_events_actor_users_id_fk" FOREIGN KEY ("actor") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "work_order_line_items" ADD CONSTRAINT "work_order_line_items_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "work_order_line_items" ADD CONSTRAINT "work_order_line_items_work_order_id_work_orders_id_fk" FOREIGN KEY ("work_order_id") REFERENCES "public"."work_orders"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "work_orders" ADD CONSTRAINT "work_orders_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "work_orders" ADD CONSTRAINT "work_orders_service_definition_id_service_definitions_id_fk" FOREIGN KEY ("service_definition_id") REFERENCES "public"."service_definitions"("id") ON DELETE restrict ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "work_orders" ADD CONSTRAINT "work_orders_customer_id_customers_id_fk" FOREIGN KEY ("customer_id") REFERENCES "public"."customers"("id") ON DELETE restrict ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "work_orders" ADD CONSTRAINT "work_orders_assigned_contractor_membership_id_memberships_id_fk" FOREIGN KEY ("assigned_contractor_membership_id") REFERENCES "public"."memberships"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "work_orders" ADD CONSTRAINT "work_orders_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "business_profiles_tenant_idx" ON "business_profiles" USING btree ("tenant_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "checklist_instances_tenant_idx" ON "checklist_instances" USING btree ("tenant_id");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "checklist_instances_work_order_unique" ON "checklist_instances" USING btree ("work_order_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "checklist_steps_tenant_idx" ON "checklist_steps" USING btree ("tenant_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "checklist_steps_instance_ordinal_idx" ON "checklist_steps" USING btree ("checklist_instance_id","ordinal");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "checklist_templates_tenant_idx" ON "checklist_templates" USING btree ("tenant_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "contractor_documents_tenant_idx" ON "contractor_documents" USING btree ("tenant_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "contractor_documents_contractor_idx" ON "contractor_documents" USING btree ("contractor_membership_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "contractor_documents_type_idx" ON "contractor_documents" USING btree ("document_type_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "contractor_documents_expires_idx" ON "contractor_documents" USING btree ("expires_on");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "customer_signoffs_tenant_idx" ON "customer_signoffs" USING btree ("tenant_id");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "customer_signoffs_work_order_unique" ON "customer_signoffs" USING btree ("work_order_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "customers_tenant_idx" ON "customers" USING btree ("tenant_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "document_types_tenant_idx" ON "document_types" USING btree ("tenant_id");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "document_types_tenant_name_unique" ON "document_types" USING btree ("tenant_id","name");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "memberships_tenant_user_unique" ON "memberships" USING btree ("tenant_id","user_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "memberships_tenant_idx" ON "memberships" USING btree ("tenant_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "memberships_user_idx" ON "memberships" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "payout_lines_tenant_idx" ON "payout_lines" USING btree ("tenant_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "payout_lines_period_idx" ON "payout_lines" USING btree ("payout_period_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "payout_lines_contractor_idx" ON "payout_lines" USING btree ("contractor_membership_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "payout_lines_work_order_idx" ON "payout_lines" USING btree ("work_order_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "payout_periods_tenant_idx" ON "payout_periods" USING btree ("tenant_id");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "payout_periods_tenant_range_unique" ON "payout_periods" USING btree ("tenant_id","period_start","period_end");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "payout_rules_tenant_idx" ON "payout_rules" USING btree ("tenant_id");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "payout_rules_tenant_name_unique" ON "payout_rules" USING btree ("tenant_id","name");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "proof_of_work_artifacts_tenant_idx" ON "proof_of_work_artifacts" USING btree ("tenant_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "proof_of_work_artifacts_work_order_idx" ON "proof_of_work_artifacts" USING btree ("work_order_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "proof_of_work_artifacts_step_idx" ON "proof_of_work_artifacts" USING btree ("checklist_step_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "safety_acknowledgements_tenant_idx" ON "safety_acknowledgements" USING btree ("tenant_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "safety_acknowledgements_contractor_idx" ON "safety_acknowledgements" USING btree ("contractor_membership_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "safety_acknowledgements_pack_idx" ON "safety_acknowledgements" USING btree ("safety_pack_id");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "safety_acknowledgements_contractor_pack_unique" ON "safety_acknowledgements" USING btree ("contractor_membership_id","safety_pack_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "safety_packs_tenant_idx" ON "safety_packs" USING btree ("tenant_id");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "safety_packs_tenant_name_version_unique" ON "safety_packs" USING btree ("tenant_id","name","version");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "service_definitions_tenant_idx" ON "service_definitions" USING btree ("tenant_id");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "service_definitions_tenant_name_unique" ON "service_definitions" USING btree ("tenant_id","name");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "users_auth_user_id_unique" ON "users" USING btree ("auth_user_id");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "users_email_lower_unique" ON "users" USING btree (lower("email"));--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "work_order_events_tenant_idx" ON "work_order_events" USING btree ("tenant_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "work_order_events_work_order_at_idx" ON "work_order_events" USING btree ("work_order_id","at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "work_order_line_items_tenant_idx" ON "work_order_line_items" USING btree ("tenant_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "work_order_line_items_work_order_idx" ON "work_order_line_items" USING btree ("work_order_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "work_orders_tenant_idx" ON "work_orders" USING btree ("tenant_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "work_orders_tenant_status_idx" ON "work_orders" USING btree ("tenant_id","status");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "work_orders_service_idx" ON "work_orders" USING btree ("service_definition_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "work_orders_customer_idx" ON "work_orders" USING btree ("customer_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "work_orders_assigned_contractor_idx" ON "work_orders" USING btree ("assigned_contractor_membership_id");

--- a/supabase/migrations/0001_phase_2_rls_and_audit.sql
+++ b/supabase/migrations/0001_phase_2_rls_and_audit.sql
@@ -1,0 +1,225 @@
+-- Phase 2 companion migration: RLS enable + tenant-isolation policies +
+-- append-only enforcement for the canonical audit table.
+--
+-- This file is hand-written (not drizzle-kit emitted). Drizzle is the
+-- source of truth for table shape; security and append-only are layered on
+-- top here so they can be reviewed independently.
+--
+-- Auth model: Supabase Auth issues `auth.uid()` (the auth.users.id UUID).
+-- A local `users` row links to it via `auth_user_id`. Tenant membership is
+-- declared by `memberships`. The compliance gate, operator dashboards, and
+-- mobile field views all flow tenant access through `memberships`.
+
+--------------------------------------------------------------------------
+-- 1. Helper: which tenants the current auth user is an ACTIVE member of?
+--------------------------------------------------------------------------
+-- SECURITY DEFINER is required so the function can read memberships and
+-- users without recursing into RLS. search_path is locked to public so the
+-- function can't be hijacked by a shadowed schema.
+
+CREATE OR REPLACE FUNCTION public.worksie_current_tenant_ids()
+RETURNS SETOF uuid
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT m.tenant_id
+  FROM memberships m
+  INNER JOIN users u ON u.id = m.user_id
+  WHERE u.auth_user_id = auth.uid()
+    AND m.status = 'active'
+$$;
+
+REVOKE ALL ON FUNCTION public.worksie_current_tenant_ids() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.worksie_current_tenant_ids() TO authenticated;
+
+--------------------------------------------------------------------------
+-- 2. Enable RLS on every canonical table.
+--------------------------------------------------------------------------
+-- Default-deny once enabled. Each table then gets a policy below.
+
+ALTER TABLE public.tenants                   ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.users                     ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.memberships               ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.business_profiles         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.service_definitions       ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.document_types            ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.contractor_documents      ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.safety_packs              ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.safety_acknowledgements   ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.work_orders               ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.work_order_line_items     ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.work_order_events         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.checklist_templates       ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.checklist_instances       ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.checklist_steps           ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.proof_of_work_artifacts   ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.customers                 ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.customer_signoffs         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.payout_rules              ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.payout_periods            ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.payout_lines              ENABLE ROW LEVEL SECURITY;
+
+--------------------------------------------------------------------------
+-- 3. Tenant isolation policies (tables that carry tenant_id).
+--------------------------------------------------------------------------
+-- One uniform policy per table: the row's tenant_id must be one the
+-- current user has an active membership in. The bootstrap path (creating
+-- the first tenant + membership) is expected to run as service_role, which
+-- bypasses RLS by Supabase convention.
+
+CREATE POLICY "tenant_isolation" ON public.tenants
+  FOR ALL TO authenticated
+  USING (id IN (SELECT public.worksie_current_tenant_ids()))
+  WITH CHECK (id IN (SELECT public.worksie_current_tenant_ids()));
+
+CREATE POLICY "tenant_isolation" ON public.business_profiles
+  FOR ALL TO authenticated
+  USING (tenant_id IN (SELECT public.worksie_current_tenant_ids()))
+  WITH CHECK (tenant_id IN (SELECT public.worksie_current_tenant_ids()));
+
+CREATE POLICY "tenant_isolation" ON public.service_definitions
+  FOR ALL TO authenticated
+  USING (tenant_id IN (SELECT public.worksie_current_tenant_ids()))
+  WITH CHECK (tenant_id IN (SELECT public.worksie_current_tenant_ids()));
+
+CREATE POLICY "tenant_isolation" ON public.document_types
+  FOR ALL TO authenticated
+  USING (tenant_id IN (SELECT public.worksie_current_tenant_ids()))
+  WITH CHECK (tenant_id IN (SELECT public.worksie_current_tenant_ids()));
+
+CREATE POLICY "tenant_isolation" ON public.contractor_documents
+  FOR ALL TO authenticated
+  USING (tenant_id IN (SELECT public.worksie_current_tenant_ids()))
+  WITH CHECK (tenant_id IN (SELECT public.worksie_current_tenant_ids()));
+
+CREATE POLICY "tenant_isolation" ON public.safety_packs
+  FOR ALL TO authenticated
+  USING (tenant_id IN (SELECT public.worksie_current_tenant_ids()))
+  WITH CHECK (tenant_id IN (SELECT public.worksie_current_tenant_ids()));
+
+CREATE POLICY "tenant_isolation" ON public.safety_acknowledgements
+  FOR ALL TO authenticated
+  USING (tenant_id IN (SELECT public.worksie_current_tenant_ids()))
+  WITH CHECK (tenant_id IN (SELECT public.worksie_current_tenant_ids()));
+
+CREATE POLICY "tenant_isolation" ON public.work_orders
+  FOR ALL TO authenticated
+  USING (tenant_id IN (SELECT public.worksie_current_tenant_ids()))
+  WITH CHECK (tenant_id IN (SELECT public.worksie_current_tenant_ids()));
+
+CREATE POLICY "tenant_isolation" ON public.work_order_line_items
+  FOR ALL TO authenticated
+  USING (tenant_id IN (SELECT public.worksie_current_tenant_ids()))
+  WITH CHECK (tenant_id IN (SELECT public.worksie_current_tenant_ids()));
+
+-- work_order_events: SELECT and INSERT only via tenant isolation. UPDATE
+-- and DELETE are blocked by triggers below (append-only).
+CREATE POLICY "tenant_isolation_select" ON public.work_order_events
+  FOR SELECT TO authenticated
+  USING (tenant_id IN (SELECT public.worksie_current_tenant_ids()));
+
+CREATE POLICY "tenant_isolation_insert" ON public.work_order_events
+  FOR INSERT TO authenticated
+  WITH CHECK (tenant_id IN (SELECT public.worksie_current_tenant_ids()));
+
+CREATE POLICY "tenant_isolation" ON public.checklist_templates
+  FOR ALL TO authenticated
+  USING (tenant_id IN (SELECT public.worksie_current_tenant_ids()))
+  WITH CHECK (tenant_id IN (SELECT public.worksie_current_tenant_ids()));
+
+CREATE POLICY "tenant_isolation" ON public.checklist_instances
+  FOR ALL TO authenticated
+  USING (tenant_id IN (SELECT public.worksie_current_tenant_ids()))
+  WITH CHECK (tenant_id IN (SELECT public.worksie_current_tenant_ids()));
+
+CREATE POLICY "tenant_isolation" ON public.checklist_steps
+  FOR ALL TO authenticated
+  USING (tenant_id IN (SELECT public.worksie_current_tenant_ids()))
+  WITH CHECK (tenant_id IN (SELECT public.worksie_current_tenant_ids()));
+
+CREATE POLICY "tenant_isolation" ON public.proof_of_work_artifacts
+  FOR ALL TO authenticated
+  USING (tenant_id IN (SELECT public.worksie_current_tenant_ids()))
+  WITH CHECK (tenant_id IN (SELECT public.worksie_current_tenant_ids()));
+
+CREATE POLICY "tenant_isolation" ON public.customers
+  FOR ALL TO authenticated
+  USING (tenant_id IN (SELECT public.worksie_current_tenant_ids()))
+  WITH CHECK (tenant_id IN (SELECT public.worksie_current_tenant_ids()));
+
+CREATE POLICY "tenant_isolation" ON public.customer_signoffs
+  FOR ALL TO authenticated
+  USING (tenant_id IN (SELECT public.worksie_current_tenant_ids()))
+  WITH CHECK (tenant_id IN (SELECT public.worksie_current_tenant_ids()));
+
+CREATE POLICY "tenant_isolation" ON public.payout_rules
+  FOR ALL TO authenticated
+  USING (tenant_id IN (SELECT public.worksie_current_tenant_ids()))
+  WITH CHECK (tenant_id IN (SELECT public.worksie_current_tenant_ids()));
+
+CREATE POLICY "tenant_isolation" ON public.payout_periods
+  FOR ALL TO authenticated
+  USING (tenant_id IN (SELECT public.worksie_current_tenant_ids()))
+  WITH CHECK (tenant_id IN (SELECT public.worksie_current_tenant_ids()));
+
+CREATE POLICY "tenant_isolation" ON public.payout_lines
+  FOR ALL TO authenticated
+  USING (tenant_id IN (SELECT public.worksie_current_tenant_ids()))
+  WITH CHECK (tenant_id IN (SELECT public.worksie_current_tenant_ids()));
+
+--------------------------------------------------------------------------
+-- 4. Identity-table policies (users, memberships).
+--------------------------------------------------------------------------
+-- users: visible to self, plus to anyone who shares an active tenant via
+-- memberships (so an operator can see contractors in their tenant).
+
+CREATE POLICY "user_self_or_shared_tenant" ON public.users
+  FOR SELECT TO authenticated
+  USING (
+    auth_user_id = auth.uid()
+    OR id IN (
+      SELECT m.user_id
+      FROM public.memberships m
+      WHERE m.tenant_id IN (SELECT public.worksie_current_tenant_ids())
+    )
+  );
+
+CREATE POLICY "user_self_insert" ON public.users
+  FOR INSERT TO authenticated
+  WITH CHECK (auth_user_id = auth.uid());
+
+CREATE POLICY "user_self_update" ON public.users
+  FOR UPDATE TO authenticated
+  USING (auth_user_id = auth.uid())
+  WITH CHECK (auth_user_id = auth.uid());
+
+-- memberships: same tenant isolation as the rest.
+CREATE POLICY "tenant_isolation" ON public.memberships
+  FOR ALL TO authenticated
+  USING (tenant_id IN (SELECT public.worksie_current_tenant_ids()))
+  WITH CHECK (tenant_id IN (SELECT public.worksie_current_tenant_ids()));
+
+--------------------------------------------------------------------------
+-- 5. Append-only enforcement for work_order_events.
+--------------------------------------------------------------------------
+-- DOMAIN_MODEL.md Hard Rule #5: "WorkOrderEvent is append-only — never
+-- updated, never deleted, not even on cancelled or voided." Enforce in DB.
+
+CREATE OR REPLACE FUNCTION public.worksie_block_work_order_event_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RAISE EXCEPTION 'work_order_events is append-only (canonical audit log)';
+END;
+$$;
+
+CREATE TRIGGER work_order_events_block_update
+BEFORE UPDATE ON public.work_order_events
+FOR EACH ROW EXECUTE FUNCTION public.worksie_block_work_order_event_mutation();
+
+CREATE TRIGGER work_order_events_block_delete
+BEFORE DELETE ON public.work_order_events
+FOR EACH ROW EXECUTE FUNCTION public.worksie_block_work_order_event_mutation();

--- a/supabase/migrations/meta/0000_snapshot.json
+++ b/supabase/migrations/meta/0000_snapshot.json
@@ -1,0 +1,2890 @@
+{
+  "id": "d0299a3e-3a97-4f33-8982-fcf39dd2611d",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.business_profiles": {
+      "name": "business_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legal_name": {
+          "name": "legal_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dba": {
+          "name": "dba",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jurisdictions": {
+          "name": "jurisdictions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "default_safety_pack_id": {
+          "name": "default_safety_pack_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "business_profiles_tenant_idx": {
+          "name": "business_profiles_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "business_profiles_tenant_id_tenants_id_fk": {
+          "name": "business_profiles_tenant_id_tenants_id_fk",
+          "tableFrom": "business_profiles",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "business_profiles_default_safety_pack_id_safety_packs_id_fk": {
+          "name": "business_profiles_default_safety_pack_id_safety_packs_id_fk",
+          "tableFrom": "business_profiles",
+          "tableTo": "safety_packs",
+          "columnsFrom": [
+            "default_safety_pack_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checklist_instances": {
+      "name": "checklist_instances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "work_order_id": {
+          "name": "work_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checklist_template_id": {
+          "name": "checklist_template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "checklist_instances_tenant_idx": {
+          "name": "checklist_instances_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "checklist_instances_work_order_unique": {
+          "name": "checklist_instances_work_order_unique",
+          "columns": [
+            {
+              "expression": "work_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "checklist_instances_tenant_id_tenants_id_fk": {
+          "name": "checklist_instances_tenant_id_tenants_id_fk",
+          "tableFrom": "checklist_instances",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "checklist_instances_work_order_id_work_orders_id_fk": {
+          "name": "checklist_instances_work_order_id_work_orders_id_fk",
+          "tableFrom": "checklist_instances",
+          "tableTo": "work_orders",
+          "columnsFrom": [
+            "work_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "checklist_instances_checklist_template_id_checklist_templates_id_fk": {
+          "name": "checklist_instances_checklist_template_id_checklist_templates_id_fk",
+          "tableFrom": "checklist_instances",
+          "tableTo": "checklist_templates",
+          "columnsFrom": [
+            "checklist_template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checklist_steps": {
+      "name": "checklist_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checklist_instance_id": {
+          "name": "checklist_instance_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requires_photo": {
+          "name": "requires_photo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requires_signature": {
+          "name": "requires_signature",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "checklist_steps_tenant_idx": {
+          "name": "checklist_steps_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "checklist_steps_instance_ordinal_idx": {
+          "name": "checklist_steps_instance_ordinal_idx",
+          "columns": [
+            {
+              "expression": "checklist_instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ordinal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "checklist_steps_tenant_id_tenants_id_fk": {
+          "name": "checklist_steps_tenant_id_tenants_id_fk",
+          "tableFrom": "checklist_steps",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "checklist_steps_checklist_instance_id_checklist_instances_id_fk": {
+          "name": "checklist_steps_checklist_instance_id_checklist_instances_id_fk",
+          "tableFrom": "checklist_steps",
+          "tableTo": "checklist_instances",
+          "columnsFrom": [
+            "checklist_instance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "checklist_steps_completed_by_users_id_fk": {
+          "name": "checklist_steps_completed_by_users_id_fk",
+          "tableFrom": "checklist_steps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "completed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checklist_templates": {
+      "name": "checklist_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps_json": {
+          "name": "steps_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "checklist_templates_tenant_idx": {
+          "name": "checklist_templates_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "checklist_templates_tenant_id_tenants_id_fk": {
+          "name": "checklist_templates_tenant_id_tenants_id_fk",
+          "tableFrom": "checklist_templates",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contractor_documents": {
+      "name": "contractor_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contractor_membership_id": {
+          "name": "contractor_membership_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_type_id": {
+          "name": "document_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_on": {
+          "name": "issued_on",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_on": {
+          "name": "expires_on",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_by": {
+          "name": "verified_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "contractor_document_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contractor_documents_tenant_idx": {
+          "name": "contractor_documents_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contractor_documents_contractor_idx": {
+          "name": "contractor_documents_contractor_idx",
+          "columns": [
+            {
+              "expression": "contractor_membership_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contractor_documents_type_idx": {
+          "name": "contractor_documents_type_idx",
+          "columns": [
+            {
+              "expression": "document_type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contractor_documents_expires_idx": {
+          "name": "contractor_documents_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contractor_documents_tenant_id_tenants_id_fk": {
+          "name": "contractor_documents_tenant_id_tenants_id_fk",
+          "tableFrom": "contractor_documents",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contractor_documents_contractor_membership_id_memberships_id_fk": {
+          "name": "contractor_documents_contractor_membership_id_memberships_id_fk",
+          "tableFrom": "contractor_documents",
+          "tableTo": "memberships",
+          "columnsFrom": [
+            "contractor_membership_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contractor_documents_document_type_id_document_types_id_fk": {
+          "name": "contractor_documents_document_type_id_document_types_id_fk",
+          "tableFrom": "contractor_documents",
+          "tableTo": "document_types",
+          "columnsFrom": [
+            "document_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "contractor_documents_verified_by_users_id_fk": {
+          "name": "contractor_documents_verified_by_users_id_fk",
+          "tableFrom": "contractor_documents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "verified_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_signoffs": {
+      "name": "customer_signoffs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "work_order_id": {
+          "name": "work_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature_file_id": {
+          "name": "signature_file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signed_name": {
+          "name": "signed_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "customer_signoffs_tenant_idx": {
+          "name": "customer_signoffs_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customer_signoffs_work_order_unique": {
+          "name": "customer_signoffs_work_order_unique",
+          "columns": [
+            {
+              "expression": "work_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_signoffs_tenant_id_tenants_id_fk": {
+          "name": "customer_signoffs_tenant_id_tenants_id_fk",
+          "tableFrom": "customer_signoffs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_signoffs_work_order_id_work_orders_id_fk": {
+          "name": "customer_signoffs_work_order_id_work_orders_id_fk",
+          "tableFrom": "customer_signoffs",
+          "tableTo": "work_orders",
+          "columnsFrom": [
+            "work_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customers": {
+      "name": "customers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "customers_tenant_idx": {
+          "name": "customers_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customers_tenant_id_tenants_id_fk": {
+          "name": "customers_tenant_id_tenants_id_fk",
+          "tableFrom": "customers",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_types": {
+      "name": "document_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applies_to": {
+          "name": "applies_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expirable": {
+          "name": "expirable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "gating": {
+          "name": "gating",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_types_tenant_idx": {
+          "name": "document_types_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_types_tenant_name_unique": {
+          "name": "document_types_tenant_name_unique",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_types_tenant_id_tenants_id_fk": {
+          "name": "document_types_tenant_id_tenants_id_fk",
+          "tableFrom": "document_types",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "document_types_applies_to_check": {
+          "name": "document_types_applies_to_check",
+          "value": "\"document_types\".\"applies_to\" IN ('contractor', 'business', 'vehicle')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.memberships": {
+      "name": "memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "membership_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "membership_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invited'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memberships_tenant_user_unique": {
+          "name": "memberships_tenant_user_unique",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memberships_tenant_idx": {
+          "name": "memberships_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memberships_user_idx": {
+          "name": "memberships_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memberships_tenant_id_tenants_id_fk": {
+          "name": "memberships_tenant_id_tenants_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memberships_user_id_users_id_fk": {
+          "name": "memberships_user_id_users_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payout_lines": {
+      "name": "payout_lines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payout_period_id": {
+          "name": "payout_period_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contractor_membership_id": {
+          "name": "contractor_membership_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "work_order_id": {
+          "name": "work_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "work_order_line_item_id": {
+          "name": "work_order_line_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(14, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computed_from": {
+          "name": "computed_from",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payout_lines_tenant_idx": {
+          "name": "payout_lines_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payout_lines_period_idx": {
+          "name": "payout_lines_period_idx",
+          "columns": [
+            {
+              "expression": "payout_period_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payout_lines_contractor_idx": {
+          "name": "payout_lines_contractor_idx",
+          "columns": [
+            {
+              "expression": "contractor_membership_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payout_lines_work_order_idx": {
+          "name": "payout_lines_work_order_idx",
+          "columns": [
+            {
+              "expression": "work_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payout_lines_tenant_id_tenants_id_fk": {
+          "name": "payout_lines_tenant_id_tenants_id_fk",
+          "tableFrom": "payout_lines",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payout_lines_payout_period_id_payout_periods_id_fk": {
+          "name": "payout_lines_payout_period_id_payout_periods_id_fk",
+          "tableFrom": "payout_lines",
+          "tableTo": "payout_periods",
+          "columnsFrom": [
+            "payout_period_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payout_lines_contractor_membership_id_memberships_id_fk": {
+          "name": "payout_lines_contractor_membership_id_memberships_id_fk",
+          "tableFrom": "payout_lines",
+          "tableTo": "memberships",
+          "columnsFrom": [
+            "contractor_membership_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "payout_lines_work_order_id_work_orders_id_fk": {
+          "name": "payout_lines_work_order_id_work_orders_id_fk",
+          "tableFrom": "payout_lines",
+          "tableTo": "work_orders",
+          "columnsFrom": [
+            "work_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "payout_lines_work_order_line_item_id_work_order_line_items_id_fk": {
+          "name": "payout_lines_work_order_line_item_id_work_order_line_items_id_fk",
+          "tableFrom": "payout_lines",
+          "tableTo": "work_order_line_items",
+          "columnsFrom": [
+            "work_order_line_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "payout_lines_computed_from_payout_rules_id_fk": {
+          "name": "payout_lines_computed_from_payout_rules_id_fk",
+          "tableFrom": "payout_lines",
+          "tableTo": "payout_rules",
+          "columnsFrom": [
+            "computed_from"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payout_periods": {
+      "name": "payout_periods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cutoff_at": {
+          "name": "cutoff_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paid_on": {
+          "name": "paid_on",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "payout_period_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payout_periods_tenant_idx": {
+          "name": "payout_periods_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payout_periods_tenant_range_unique": {
+          "name": "payout_periods_tenant_range_unique",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payout_periods_tenant_id_tenants_id_fk": {
+          "name": "payout_periods_tenant_id_tenants_id_fk",
+          "tableFrom": "payout_periods",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payout_rules": {
+      "name": "payout_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "payout_rule_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate_table_json": {
+          "name": "rate_table_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payout_rules_tenant_idx": {
+          "name": "payout_rules_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payout_rules_tenant_name_unique": {
+          "name": "payout_rules_tenant_name_unique",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payout_rules_tenant_id_tenants_id_fk": {
+          "name": "payout_rules_tenant_id_tenants_id_fk",
+          "tableFrom": "payout_rules",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proof_of_work_artifacts": {
+      "name": "proof_of_work_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "work_order_id": {
+          "name": "work_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checklist_step_id": {
+          "name": "checklist_step_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "proof_of_work_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_file_uri": {
+          "name": "local_file_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gps": {
+          "name": "gps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_by": {
+          "name": "captured_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "proof_of_work_artifacts_tenant_idx": {
+          "name": "proof_of_work_artifacts_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proof_of_work_artifacts_work_order_idx": {
+          "name": "proof_of_work_artifacts_work_order_idx",
+          "columns": [
+            {
+              "expression": "work_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "proof_of_work_artifacts_step_idx": {
+          "name": "proof_of_work_artifacts_step_idx",
+          "columns": [
+            {
+              "expression": "checklist_step_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "proof_of_work_artifacts_tenant_id_tenants_id_fk": {
+          "name": "proof_of_work_artifacts_tenant_id_tenants_id_fk",
+          "tableFrom": "proof_of_work_artifacts",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "proof_of_work_artifacts_work_order_id_work_orders_id_fk": {
+          "name": "proof_of_work_artifacts_work_order_id_work_orders_id_fk",
+          "tableFrom": "proof_of_work_artifacts",
+          "tableTo": "work_orders",
+          "columnsFrom": [
+            "work_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "proof_of_work_artifacts_checklist_step_id_checklist_steps_id_fk": {
+          "name": "proof_of_work_artifacts_checklist_step_id_checklist_steps_id_fk",
+          "tableFrom": "proof_of_work_artifacts",
+          "tableTo": "checklist_steps",
+          "columnsFrom": [
+            "checklist_step_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "proof_of_work_artifacts_captured_by_users_id_fk": {
+          "name": "proof_of_work_artifacts_captured_by_users_id_fk",
+          "tableFrom": "proof_of_work_artifacts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "captured_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.safety_acknowledgements": {
+      "name": "safety_acknowledgements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contractor_membership_id": {
+          "name": "contractor_membership_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "safety_pack_id": {
+          "name": "safety_pack_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature_file_id": {
+          "name": "signature_file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "safety_acknowledgements_tenant_idx": {
+          "name": "safety_acknowledgements_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "safety_acknowledgements_contractor_idx": {
+          "name": "safety_acknowledgements_contractor_idx",
+          "columns": [
+            {
+              "expression": "contractor_membership_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "safety_acknowledgements_pack_idx": {
+          "name": "safety_acknowledgements_pack_idx",
+          "columns": [
+            {
+              "expression": "safety_pack_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "safety_acknowledgements_contractor_pack_unique": {
+          "name": "safety_acknowledgements_contractor_pack_unique",
+          "columns": [
+            {
+              "expression": "contractor_membership_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "safety_pack_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "safety_acknowledgements_tenant_id_tenants_id_fk": {
+          "name": "safety_acknowledgements_tenant_id_tenants_id_fk",
+          "tableFrom": "safety_acknowledgements",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "safety_acknowledgements_contractor_membership_id_memberships_id_fk": {
+          "name": "safety_acknowledgements_contractor_membership_id_memberships_id_fk",
+          "tableFrom": "safety_acknowledgements",
+          "tableTo": "memberships",
+          "columnsFrom": [
+            "contractor_membership_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "safety_acknowledgements_safety_pack_id_safety_packs_id_fk": {
+          "name": "safety_acknowledgements_safety_pack_id_safety_packs_id_fk",
+          "tableFrom": "safety_acknowledgements",
+          "tableTo": "safety_packs",
+          "columnsFrom": [
+            "safety_pack_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.safety_packs": {
+      "name": "safety_packs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "content_ref": {
+          "name": "content_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "safety_packs_tenant_idx": {
+          "name": "safety_packs_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "safety_packs_tenant_name_version_unique": {
+          "name": "safety_packs_tenant_name_version_unique",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "safety_packs_tenant_id_tenants_id_fk": {
+          "name": "safety_packs_tenant_id_tenants_id_fk",
+          "tableFrom": "safety_packs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_definitions": {
+      "name": "service_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_payout_rule_id": {
+          "name": "default_payout_rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checklist_template_id": {
+          "name": "checklist_template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_gear": {
+          "name": "required_gear",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "required_documents": {
+          "name": "required_documents",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "required_safety_steps": {
+          "name": "required_safety_steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "customer_signoff_required": {
+          "name": "customer_signoff_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "service_definitions_tenant_idx": {
+          "name": "service_definitions_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_definitions_tenant_name_unique": {
+          "name": "service_definitions_tenant_name_unique",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "service_definitions_tenant_id_tenants_id_fk": {
+          "name": "service_definitions_tenant_id_tenants_id_fk",
+          "tableFrom": "service_definitions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "service_definitions_default_payout_rule_id_payout_rules_id_fk": {
+          "name": "service_definitions_default_payout_rule_id_payout_rules_id_fk",
+          "tableFrom": "service_definitions",
+          "tableTo": "payout_rules",
+          "columnsFrom": [
+            "default_payout_rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "service_definitions_checklist_template_id_checklist_templates_id_fk": {
+          "name": "service_definitions_checklist_template_id_checklist_templates_id_fk",
+          "tableFrom": "service_definitions",
+          "tableTo": "checklist_templates",
+          "columnsFrom": [
+            "checklist_template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_payout_period": {
+          "name": "default_payout_period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'weekly_mon_sun'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_auth_user_id_unique": {
+          "name": "users_auth_user_id_unique",
+          "columns": [
+            {
+              "expression": "auth_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_lower_unique": {
+          "name": "users_email_lower_unique",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.work_order_events": {
+      "name": "work_order_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "work_order_id": {
+          "name": "work_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_state": {
+          "name": "from_state",
+          "type": "work_order_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_state": {
+          "name": "to_state",
+          "type": "work_order_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "work_order_event_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "work_order_events_tenant_idx": {
+          "name": "work_order_events_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_order_events_work_order_at_idx": {
+          "name": "work_order_events_work_order_at_idx",
+          "columns": [
+            {
+              "expression": "work_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "work_order_events_tenant_id_tenants_id_fk": {
+          "name": "work_order_events_tenant_id_tenants_id_fk",
+          "tableFrom": "work_order_events",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "work_order_events_work_order_id_work_orders_id_fk": {
+          "name": "work_order_events_work_order_id_work_orders_id_fk",
+          "tableFrom": "work_order_events",
+          "tableTo": "work_orders",
+          "columnsFrom": [
+            "work_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "work_order_events_actor_users_id_fk": {
+          "name": "work_order_events_actor_users_id_fk",
+          "tableFrom": "work_order_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "work_order_events_cancelled_voided_needs_reason": {
+          "name": "work_order_events_cancelled_voided_needs_reason",
+          "value": "\"work_order_events\".\"to_state\" NOT IN ('cancelled', 'voided') OR (\"work_order_events\".\"reason\" IS NOT NULL AND length(btrim(\"work_order_events\".\"reason\")) > 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.work_order_line_items": {
+      "name": "work_order_line_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "work_order_id": {
+          "name": "work_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(12, 3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'each'"
+        },
+        "piece_rate_amount": {
+          "name": "piece_rate_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "work_order_line_items_tenant_idx": {
+          "name": "work_order_line_items_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_order_line_items_work_order_idx": {
+          "name": "work_order_line_items_work_order_idx",
+          "columns": [
+            {
+              "expression": "work_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "work_order_line_items_tenant_id_tenants_id_fk": {
+          "name": "work_order_line_items_tenant_id_tenants_id_fk",
+          "tableFrom": "work_order_line_items",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "work_order_line_items_work_order_id_work_orders_id_fk": {
+          "name": "work_order_line_items_work_order_id_work_orders_id_fk",
+          "tableFrom": "work_order_line_items",
+          "tableTo": "work_orders",
+          "columnsFrom": [
+            "work_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.work_orders": {
+      "name": "work_orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_definition_id": {
+          "name": "service_definition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_snapshot_json": {
+          "name": "service_snapshot_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gps": {
+          "name": "gps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_contractor_membership_id": {
+          "name": "assigned_contractor_membership_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "work_order_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "work_orders_tenant_idx": {
+          "name": "work_orders_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_orders_tenant_status_idx": {
+          "name": "work_orders_tenant_status_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_orders_service_idx": {
+          "name": "work_orders_service_idx",
+          "columns": [
+            {
+              "expression": "service_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_orders_customer_idx": {
+          "name": "work_orders_customer_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "work_orders_assigned_contractor_idx": {
+          "name": "work_orders_assigned_contractor_idx",
+          "columns": [
+            {
+              "expression": "assigned_contractor_membership_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "work_orders_tenant_id_tenants_id_fk": {
+          "name": "work_orders_tenant_id_tenants_id_fk",
+          "tableFrom": "work_orders",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "work_orders_service_definition_id_service_definitions_id_fk": {
+          "name": "work_orders_service_definition_id_service_definitions_id_fk",
+          "tableFrom": "work_orders",
+          "tableTo": "service_definitions",
+          "columnsFrom": [
+            "service_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "work_orders_customer_id_customers_id_fk": {
+          "name": "work_orders_customer_id_customers_id_fk",
+          "tableFrom": "work_orders",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "work_orders_assigned_contractor_membership_id_memberships_id_fk": {
+          "name": "work_orders_assigned_contractor_membership_id_memberships_id_fk",
+          "tableFrom": "work_orders",
+          "tableTo": "memberships",
+          "columnsFrom": [
+            "assigned_contractor_membership_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "work_orders_created_by_users_id_fk": {
+          "name": "work_orders_created_by_users_id_fk",
+          "tableFrom": "work_orders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.contractor_document_status": {
+      "name": "contractor_document_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "verified",
+        "rejected",
+        "expired"
+      ]
+    },
+    "public.membership_role": {
+      "name": "membership_role",
+      "schema": "public",
+      "values": [
+        "operator",
+        "back_office",
+        "contractor",
+        "customer"
+      ]
+    },
+    "public.membership_status": {
+      "name": "membership_status",
+      "schema": "public",
+      "values": [
+        "invited",
+        "active",
+        "suspended"
+      ]
+    },
+    "public.payout_period_status": {
+      "name": "payout_period_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "draft",
+        "approved",
+        "paid"
+      ]
+    },
+    "public.payout_rule_mode": {
+      "name": "payout_rule_mode",
+      "schema": "public",
+      "values": [
+        "piece_rate",
+        "completion_flat",
+        "hourly_capped"
+      ]
+    },
+    "public.proof_of_work_kind": {
+      "name": "proof_of_work_kind",
+      "schema": "public",
+      "values": [
+        "photo",
+        "video",
+        "signature",
+        "pdf",
+        "note"
+      ]
+    },
+    "public.work_order_event_source": {
+      "name": "work_order_event_source",
+      "schema": "public",
+      "values": [
+        "web_admin",
+        "mobile",
+        "system"
+      ]
+    },
+    "public.work_order_state": {
+      "name": "work_order_state",
+      "schema": "public",
+      "values": [
+        "draft",
+        "scheduled",
+        "dispatched",
+        "in_progress",
+        "awaiting_signoff",
+        "completed",
+        "invoiced",
+        "paid_out",
+        "cancelled",
+        "voided"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/supabase/migrations/meta/_journal.json
+++ b/supabase/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1779021902134,
+      "tag": "0000_phase_2_canonical_schema",
+      "breakpoints": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Materializes `docs/DOMAIN_MODEL.md` into Drizzle. All **21 entities** from `@worksie/domain` `ENTITY_NAMES` are present and the only ones — zero ontology drift.

| # | Entity | Table |
|---|--------|-------|
| 1 | Tenant | `tenants` |
| 2 | User | `users` |
| 3 | Membership | `memberships` |
| 4 | BusinessProfile | `business_profiles` |
| 5 | ServiceDefinition | `service_definitions` |
| 6 | DocumentType | `document_types` |
| 7 | ContractorDocument | `contractor_documents` |
| 8 | SafetyPack | `safety_packs` |
| 9 | SafetyAcknowledgement | `safety_acknowledgements` |
| 10 | WorkOrder | `work_orders` |
| 11 | WorkOrderLineItem | `work_order_line_items` |
| 12 | WorkOrderEvent | `work_order_events` |
| 13 | ChecklistTemplate | `checklist_templates` |
| 14 | ChecklistInstance | `checklist_instances` |
| 15 | ChecklistStep | `checklist_steps` |
| 16 | ProofOfWorkArtifact | `proof_of_work_artifacts` |
| 17 | Customer | `customers` |
| 18 | CustomerSignoff | `customer_signoffs` |
| 19 | PayoutRule | `payout_rules` |
| 20 | PayoutPeriod | `payout_periods` |
| 21 | PayoutLine | `payout_lines` |

Eight `pgEnum` types are mirrored from the domain literal arrays so a domain-level addition surfaces as a schema diff (no two sources of truth).

## What landed

### `packages/db/src/schema/`
- **`enums.ts`** — pgEnum types sourced from `@worksie/domain` (`work_order_state`, `work_order_event_source`, `membership_role`, `membership_status`, `contractor_document_status`, `payout_rule_mode`, `payout_period_status`, `proof_of_work_kind`).
- **`tables.ts`** — the 21 canonical tables. `tenant_id` on every non-tenant row. FKs with appropriate cascade / restrict / set-null. Tenant-scoped uniques (`document_types(tenant_id, name)`, `service_definitions(tenant_id, name)`, `memberships(tenant_id, user_id)`, `safety_packs(tenant_id, name, version)`, `payout_periods(tenant_id, period_start, period_end)`, `safety_acknowledgements(contractor_membership_id, safety_pack_id)`, `checklist_instances(work_order_id)`, `customer_signoffs(work_order_id)`). Booleans from the domain spec (`expirable`, `gating`, `customer_signoff_required`, `requires_photo`, `requires_signature`) are native pg `boolean`. Check constraints enforce `work_order_events.reason` for `cancelled`/`voided` and `document_types.applies_to ∈ {contractor, business, vehicle}`.
- **`index.ts`** — re-exports plus a frozen `schema` object indexed in the same order as `ENTITY_NAMES`.

### `packages/db/src/client.ts`
`createDbClient` now passes `schema` to `drizzle()`, so query builders get inferred row and insert types.

### `supabase/migrations/`
- **`0000_phase_2_canonical_schema.sql`** — drizzle-kit-emitted: 21 tables, 8 enums, FKs, indexes, check constraints.
- **`0001_phase_2_rls_and_audit.sql`** — hand-written companion:
  - `worksie_current_tenant_ids()` SECURITY DEFINER helper (locked `search_path=public`).
  - RLS enabled on every canonical table.
  - Tenant-isolation policies (`SELECT`/`INSERT`-only on `work_order_events`; full `ALL` elsewhere).
  - `user_self_or_shared_tenant` SELECT policy on `users` so an operator can see contractors in their tenant.
  - Append-only trigger on `work_order_events` enforcing `DOMAIN_MODEL.md` Hard Rule #5 (block `UPDATE` / `DELETE` at the DB).

## Deliberately NOT present (zero drift)

- ❌ no `invoices` table (`invoiced` is only a `work_order_state`)
- ❌ no `payout_cycles`
- ❌ no generic `audit_events` (only `work_order_events` per spec)
- ❌ no `capabilities` table (capability is modeled via `service_definitions` per the spine)
- ❌ no junction tables for `required_documents` / `required_safety_steps` — jsonb id arrays as the spec implies

## Verification

```
pnpm lint       ✅
pnpm typecheck  ✅
pnpm build      ✅
```

## Test plan

- [ ] Reviewer confirms entity parity vs `docs/DOMAIN_MODEL.md` (21 tables, no extras).
- [ ] Reviewer confirms `packages/db/src/schema/index.ts` `schema` object matches `ENTITY_NAMES` order in `@worksie/domain`.
- [ ] Apply `0000` + `0001` to a fresh Supabase Postgres and confirm clean migration (no manual fixes needed).
- [ ] Confirm RLS default-deny: a `SET ROLE authenticated` session with no membership cannot select from `work_orders`.
- [ ] Confirm append-only: `UPDATE work_order_events …` and `DELETE FROM work_order_events …` both raise.
- [ ] Confirm `work_order_events.reason` check constraint rejects an insert with `to_state IN ('cancelled', 'voided')` and `reason IS NULL`.
- [ ] Confirm tenant isolation: a user with membership in tenant A cannot select rows from tenant B.


---
_Generated by [Claude Code](https://claude.ai/code/session_017ViiotyA8MjHYdkFpYRnP2)_