### PR TITLE
feat(auth): Phase 3 tenant/auth boundary foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# Worksie monorepo — environment template.
+# Copy to .env.local at the repo root (or in apps/web/.env.local) and fill in
+# real values. Never commit .env.local. Never put the service-role key in
+# any file consumed by the browser bundle.
+
+# ---- Browser-safe (NEXT_PUBLIC_*) -----------------------------------------
+# These two are inlined into the Next.js client bundle. Use the Supabase
+# *anon* (publishable) key only.
+NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
+NEXT_PUBLIC_SUPABASE_ANON_KEY=replace-with-supabase-anon-key
+
+# ---- Server-only (NEVER NEXT_PUBLIC_*) ------------------------------------
+# Used by RLS verification scripts and future server-only admin tasks.
+# Must NOT be exposed to the browser. @worksie/auth's separate
+# `readSupabaseServiceRoleEnv` helper is the only sanctioned reader.
+SUPABASE_URL=http://127.0.0.1:54321
+SUPABASE_SERVICE_ROLE_KEY=replace-with-supabase-service-role-key
+
+# Optional: direct Postgres URL used by scripts/verify-rls. Defaults to the
+# Supabase CLI's standard local Postgres URL when unset.
+# WORKSIE_VERIFY_DATABASE_URL=postgres://postgres:postgres@127.0.0.1:54322/postgres

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  transpilePackages: ["@worksie/domain", "@worksie/types"]
+  transpilePackages: ["@worksie/auth", "@worksie/domain", "@worksie/types"]
 };
 
 export default nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,9 @@
     "clean": "rm -rf .next .turbo node_modules"
   },
   "dependencies": {
+    "@supabase/ssr": "^0.5.2",
+    "@supabase/supabase-js": "^2.46.1",
+    "@worksie/auth": "workspace:*",
     "@worksie/domain": "workspace:*",
     "@worksie/types": "workspace:*",
     "next": "15.0.3",

--- a/apps/web/src/app/healthz/route.ts
+++ b/apps/web/src/app/healthz/route.ts
@@ -3,5 +3,5 @@ import { NextResponse } from "next/server";
 export const dynamic = "force-static";
 
 export function GET() {
-  return NextResponse.json({ ok: true, phase: "1" });
+  return NextResponse.json({ ok: true, phase: "3" });
 }

--- a/apps/web/src/app/me/page.tsx
+++ b/apps/web/src/app/me/page.tsx
@@ -1,0 +1,101 @@
+// Phase 3 protected status page. No product UI — just renders the
+// current auth/tenant resolution so an operator can verify the boundary
+// is wired up correctly end-to-end:
+//
+//   1. Supabase session present?
+//   2. public.users row joined to auth.users via auth_user_id?
+//   3. Active membership(s) visible under RLS?
+//   4. Tenant resolved (single vs. multiple)?
+//
+// Middleware (see ../middleware.ts) already redirects unauthenticated
+// visitors away from /me. The "unauthenticated" branch below is a
+// belt-and-suspenders fallback in case middleware is bypassed.
+
+import {
+  describeTenantContextError,
+  loadCurrentTenantContext
+} from "@/lib/tenant/context";
+
+export const dynamic = "force-dynamic";
+
+export default async function MePage() {
+  const result = await loadCurrentTenantContext();
+
+  return (
+    <main className="min-h-screen p-8 max-w-2xl mx-auto">
+      <header className="mb-6">
+        <h1 className="text-2xl font-semibold">Auth / tenant status</h1>
+        <p className="text-sm opacity-70 mt-1">
+          Phase 3 boundary check. This page intentionally has no product
+          functionality.
+        </p>
+      </header>
+
+      {result.ok ? <ContextOk result={result} /> : <ContextError result={result} />}
+    </main>
+  );
+}
+
+type OkResult = Extract<
+  Awaited<ReturnType<typeof loadCurrentTenantContext>>,
+  { ok: true }
+>;
+type ErrResult = Extract<
+  Awaited<ReturnType<typeof loadCurrentTenantContext>>,
+  { ok: false }
+>;
+
+function ContextOk({ result }: { result: OkResult }) {
+  return (
+    <section className="space-y-4">
+      <StatusRow label="Auth user" value={result.authUser.email} />
+      <StatusRow label="Worksie user id" value={result.user.id} />
+      <StatusRow
+        label="Display name"
+        value={result.user.displayName ?? "(not set)"}
+      />
+      <StatusRow label="Tenant" value={result.tenant.name} />
+      <StatusRow label="Tenant id" value={result.tenant.id} />
+      <StatusRow label="Tenant timezone" value={result.tenant.timezone} />
+      <StatusRow label="Membership role" value={result.membership.role} />
+      <StatusRow label="Membership status" value={result.membership.status} />
+    </section>
+  );
+}
+
+function ContextError({ result }: { result: ErrResult }) {
+  return (
+    <section className="space-y-4">
+      <div className="rounded border border-amber-400 bg-amber-50 p-4 text-sm">
+        <strong className="block">Tenant context unresolved</strong>
+        <span>{describeTenantContextError(result.reason)}</span>
+        <span className="block mt-1 text-xs opacity-70">
+          reason: <code>{result.reason}</code>
+        </span>
+      </div>
+      <StatusRow
+        label="Auth user"
+        value={result.authUser?.email ?? "(none)"}
+      />
+      <StatusRow
+        label="Worksie user id"
+        value={result.user?.id ?? "(none)"}
+      />
+      <StatusRow
+        label="Memberships visible under RLS"
+        value={String(result.memberships.length)}
+      />
+    </section>
+  );
+}
+
+function StatusRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col sm:flex-row sm:items-baseline sm:justify-between border-b border-black/10 pb-2">
+      <span className="text-xs uppercase tracking-wide opacity-60">
+        {label}
+      </span>
+      <span className="font-mono text-sm break-all">{value}</span>
+    </div>
+  );
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,11 +1,31 @@
-export default function Home() {
+// Phase 3 marketing/landing surface. Intentionally minimal — no product
+// UI lives here. The /me route is the protected boundary; this page
+// just acknowledges the redirect notice when middleware sent the user
+// back because they weren't signed in.
+
+type SearchParams = Promise<Record<string, string | string[] | undefined>>;
+
+export default async function Home({
+  searchParams
+}: {
+  searchParams: SearchParams;
+}) {
+  const params = await searchParams;
+  const notice = typeof params.notice === "string" ? params.notice : null;
+
   return (
     <main className="min-h-screen flex items-center justify-center p-8">
       <div className="max-w-xl text-center">
         <h1 className="text-3xl font-semibold">Worksie</h1>
         <p className="mt-2 text-sm opacity-70">
-          Phase 1 scaffold. See <code>/healthz</code> for liveness.
+          Phase 3 scaffold. See <code>/healthz</code> for liveness and
+          <code> /me</code> for the protected auth/tenant boundary.
         </p>
+        {notice === "signin_required" ? (
+          <p className="mt-4 rounded border border-amber-400 bg-amber-50 px-3 py-2 text-sm">
+            Sign-in required to view <code>/me</code>.
+          </p>
+        ) : null}
       </div>
     </main>
   );

--- a/apps/web/src/lib/supabase/browser.ts
+++ b/apps/web/src/lib/supabase/browser.ts
@@ -1,0 +1,30 @@
+"use client";
+
+// Browser Supabase client. Wraps @supabase/ssr's createBrowserClient so
+// the session is read from cookies set by the server runtime. Only the
+// NEXT_PUBLIC_* env vars are referenced here — Next.js inlines those at
+// build time, so this file is safe to ship to the browser bundle.
+//
+// The service-role key MUST NOT be imported into any module that this
+// one transitively pulls in. @worksie/auth's `readSupabaseServiceRoleEnv`
+// is the only entry point for the service-role key and it is documented
+// as server-only.
+
+import { createBrowserClient } from "@supabase/ssr";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+let cached: SupabaseClient | null = null;
+
+export function getBrowserSupabaseClient(): SupabaseClient {
+  if (cached) return cached;
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!url || !anonKey) {
+    throw new Error(
+      "Supabase browser client is missing NEXT_PUBLIC_SUPABASE_URL / " +
+        "NEXT_PUBLIC_SUPABASE_ANON_KEY. See docs/PHASE_3_AUTH.md."
+    );
+  }
+  cached = createBrowserClient(url, anonKey);
+  return cached;
+}

--- a/apps/web/src/lib/supabase/server.ts
+++ b/apps/web/src/lib/supabase/server.ts
@@ -1,0 +1,43 @@
+// Server Supabase client for the Next.js App Router. Uses
+// @supabase/ssr's cookie bridge so server components and route handlers
+// see the same session the browser does.
+//
+// IMPORTANT: this module is server-only. It uses next/headers, which is
+// not callable from a "use client" boundary, so importing it from a
+// client component will be a build-time error. We still validate the
+// public env here (not the service-role key) — the service-role key is
+// available only via `@worksie/auth`'s explicit, separate entry point.
+
+import { cookies } from "next/headers";
+import { createServerClient, type CookieOptions } from "@supabase/ssr";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import { readSupabasePublicEnv } from "@worksie/auth";
+
+type CookieToSet = { name: string; value: string; options: CookieOptions };
+
+export async function getServerSupabaseClient(): Promise<SupabaseClient> {
+  const env = readSupabasePublicEnv();
+  const cookieStore = await cookies();
+
+  return createServerClient(env.url, env.anonKey, {
+    cookies: {
+      getAll() {
+        return cookieStore.getAll();
+      },
+      setAll(toSet: CookieToSet[]) {
+        // Server components can't write cookies; @supabase/ssr handles
+        // that path via middleware. We swallow the write here so a
+        // refresh during render doesn't throw. The middleware in
+        // apps/web/src/middleware.ts performs the actual rotation.
+        try {
+          for (const { name, value, options } of toSet) {
+            cookieStore.set(name, value, options);
+          }
+        } catch {
+          // Not in a mutable context (e.g. server component render).
+        }
+      }
+    }
+  });
+}

--- a/apps/web/src/lib/tenant/context.ts
+++ b/apps/web/src/lib/tenant/context.ts
@@ -1,0 +1,133 @@
+// Server-only tenant-context loader. Wires the Supabase server client
+// into @worksie/auth's `resolveTenantContext`. All reads go through the
+// authenticated Supabase client so RLS is the boundary — this code does
+// NOT use the service-role key.
+//
+// We only read three canonical tables: `users`, `memberships`, and
+// `tenants`. No product tables. No mutations.
+
+import "server-only";
+
+import {
+  describeTenantContextError,
+  resolveTenantContext,
+  type AppUser,
+  type AuthUser,
+  type Membership,
+  type Tenant,
+  type TenantContextResult
+} from "@worksie/auth";
+import type {
+  MembershipRole,
+  MembershipStatus
+} from "@worksie/domain";
+
+import { getServerSupabaseClient } from "@/lib/supabase/server";
+
+type MembershipRow = {
+  id: string;
+  tenant_id: string;
+  user_id: string;
+  role: string;
+  status: string;
+};
+
+type UserRow = {
+  id: string;
+  auth_user_id: string;
+  email: string;
+  display_name: string | null;
+  phone: string | null;
+};
+
+type TenantRow = {
+  id: string;
+  name: string;
+  timezone: string;
+};
+
+export async function loadCurrentTenantContext(options: {
+  preferredTenantId?: string;
+} = {}): Promise<TenantContextResult> {
+  const supabase = await getServerSupabaseClient();
+
+  const {
+    data: { user: sessionUser }
+  } = await supabase.auth.getUser();
+
+  const authUser: AuthUser | null = sessionUser
+    ? {
+        authUserId: sessionUser.id,
+        email: sessionUser.email ?? ""
+      }
+    : null;
+
+  // Pre-load via the same authenticated session. RLS will hide rows the
+  // caller cannot see — exactly the behaviour the resolver expects.
+  const user = authUser ? await fetchAppUser(supabase, authUser.authUserId) : null;
+  const memberships = user ? await fetchMemberships(supabase, user.id) : [];
+
+  return resolveTenantContext({
+    authUser,
+    user,
+    memberships,
+    preferredTenantId: options.preferredTenantId,
+    loadTenant: (tenantId) => fetchTenant(supabase, tenantId)
+  });
+}
+
+async function fetchAppUser(
+  supabase: Awaited<ReturnType<typeof getServerSupabaseClient>>,
+  authUserId: string
+): Promise<AppUser | null> {
+  const { data } = await supabase
+    .from("users")
+    .select("id, auth_user_id, email, display_name, phone")
+    .eq("auth_user_id", authUserId)
+    .maybeSingle<UserRow>();
+
+  if (!data) return null;
+  return {
+    id: data.id,
+    authUserId: data.auth_user_id,
+    email: data.email,
+    displayName: data.display_name,
+    phone: data.phone
+  };
+}
+
+async function fetchMemberships(
+  supabase: Awaited<ReturnType<typeof getServerSupabaseClient>>,
+  userId: string
+): Promise<Membership[]> {
+  const { data } = await supabase
+    .from("memberships")
+    .select("id, tenant_id, user_id, role, status")
+    .eq("user_id", userId)
+    .returns<MembershipRow[]>();
+
+  if (!data) return [];
+  return data.map((row) => ({
+    id: row.id,
+    tenantId: row.tenant_id,
+    userId: row.user_id,
+    role: row.role as MembershipRole,
+    status: row.status as MembershipStatus
+  }));
+}
+
+async function fetchTenant(
+  supabase: Awaited<ReturnType<typeof getServerSupabaseClient>>,
+  tenantId: string
+): Promise<Tenant | null> {
+  const { data } = await supabase
+    .from("tenants")
+    .select("id, name, timezone")
+    .eq("id", tenantId)
+    .maybeSingle<TenantRow>();
+
+  if (!data) return null;
+  return { id: data.id, name: data.name, timezone: data.timezone };
+}
+
+export { describeTenantContextError };

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,0 +1,65 @@
+// Edge middleware: refresh the Supabase session cookie on every request
+// before the route handler runs. @supabase/ssr expects this so that a
+// silently-expired access token gets rotated and downstream server
+// components see a valid session.
+//
+// Protected routes (/me) are also gated here: if the user has no
+// session, redirect to / with a notice. We intentionally don't expose
+// any product routes yet — Phase 3 is auth/tenant boundary only.
+
+import { NextResponse, type NextRequest } from "next/server";
+import { createServerClient, type CookieOptions } from "@supabase/ssr";
+
+import { readSupabasePublicEnv } from "@worksie/auth";
+
+type CookieToSet = { name: string; value: string; options: CookieOptions };
+
+const PROTECTED_PREFIXES = ["/me"];
+
+export async function middleware(request: NextRequest) {
+  const env = readSupabasePublicEnv();
+
+  // We rebuild the response each pass so cookie mutations from the
+  // Supabase client (refresh-rotation) make it back to the browser.
+  let response = NextResponse.next({ request });
+
+  const supabase = createServerClient(env.url, env.anonKey, {
+    cookies: {
+      getAll() {
+        return request.cookies.getAll();
+      },
+      setAll(toSet: CookieToSet[]) {
+        for (const { name, value } of toSet) {
+          request.cookies.set(name, value);
+        }
+        response = NextResponse.next({ request });
+        for (const { name, value, options } of toSet) {
+          response.cookies.set(name, value, options);
+        }
+      }
+    }
+  });
+
+  // Touching getUser() forces token refresh if needed and ensures
+  // cookies are rotated via the setAll callback above.
+  const { data } = await supabase.auth.getUser();
+
+  if (
+    !data.user &&
+    PROTECTED_PREFIXES.some((p) => request.nextUrl.pathname.startsWith(p))
+  ) {
+    const redirect = request.nextUrl.clone();
+    redirect.pathname = "/";
+    redirect.searchParams.set("notice", "signin_required");
+    return NextResponse.redirect(redirect);
+  }
+
+  return response;
+}
+
+export const config = {
+  // Match everything except Next internals + static assets. We need this
+  // to run on /me (protected) and on / (so anonymous sessions still get
+  // their cookies refreshed if a future flow needs them).
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"]
+};

--- a/docs/PHASE_3_AUTH.md
+++ b/docs/PHASE_3_AUTH.md
@@ -1,0 +1,183 @@
+# Phase 3 — Tenant / Auth Boundary
+
+This document captures the minimal contract added in Phase 3: Supabase
+Auth identity, the tenant-context resolver, RLS verification, and the
+single protected route (`/me`).
+
+Phase 3 is intentionally boundary-only. There is no product UI, no work
+order workflow, no payout execution, no Stripe/Resend/Twilio, no
+PowerSync. Those land in Phase 4+.
+
+## Architecture
+
+```
++----------------------------+      +-------------------------------+
+|  apps/web (Next 15 App)    |      |  Supabase                     |
+|  - middleware.ts           |<---->|  - Auth (auth.users)          |
+|  - /me page                |      |  - Postgres + RLS             |
+|  - lib/supabase/{browser,  |      |  - canonical 21-entity schema |
+|     server}.ts             |      |    (PR #23 — unchanged)       |
+|  - lib/tenant/context.ts   |      +-------------------------------+
++----------------------------+
+              |
+              v
+    +---------------------+
+    |  @worksie/auth      |  (transport-free)
+    |  - env validation   |
+    |  - tenant resolver  |
+    +---------------------+
+```
+
+Identity: Supabase Auth issues `auth.users.id`. A local `public.users`
+row links to it via `auth_user_id` (1:1 unique). Tenant access lives in
+`public.memberships`. RLS uses `public.worksie_current_tenant_ids()`
+(defined in `0001_phase_2_rls_and_audit.sql`) to scope reads/writes.
+
+## Env contract
+
+Copy `.env.example` to `.env.local` (at the repo root for the web app,
+and again for scripts that need the service-role key — see below).
+
+| Variable                          | Where it's read                       | Bundle |
+|-----------------------------------|---------------------------------------|--------|
+| `NEXT_PUBLIC_SUPABASE_URL`        | browser + server runtime              | ✅ browser-safe |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY`   | browser + server runtime              | ✅ browser-safe |
+| `SUPABASE_URL`                    | server-only scripts                   | ❌ server-only |
+| `SUPABASE_SERVICE_ROLE_KEY`       | server-only scripts                   | ❌ server-only |
+| `WORKSIE_VERIFY_DATABASE_URL`     | `scripts/verify-rls` (optional)        | ❌ server-only |
+
+`@worksie/auth` exposes two separate readers:
+`readSupabasePublicEnv()` for the browser-safe pair and
+`readSupabaseServiceRoleEnv()` for the server-only pair. The names are
+deliberately long so a code-review pass can catch the service-role
+helper being imported into a client component.
+
+## Tenant context resolver
+
+`@worksie/auth/tenant#resolveTenantContext` takes preloaded values
+(`authUser`, `user`, `memberships`, plus a `loadTenant` callback) and
+returns one of:
+
+| Outcome             | When                                                     |
+|---------------------|----------------------------------------------------------|
+| `ok: true`          | Single active membership, or `preferredTenantId` matches |
+| `unauthenticated`   | No Supabase session                                      |
+| `no_user_row`       | Session present but no `public.users` row yet            |
+| `no_membership`     | User exists but zero memberships                         |
+| `no_active_membership` | All memberships are `invited` or `suspended`          |
+| `multiple_memberships` | More than one `active` membership and no preference   |
+
+`multiple_memberships` is deliberately an error rather than a silent
+pick. Phase 4+ will add an explicit tenant switcher.
+
+## Protected route
+
+- `/me` (server component) renders the resolver's output verbatim.
+  No mutations, no product surface.
+- Unauthenticated visitors are redirected to `/?notice=signin_required`
+  by `apps/web/src/middleware.ts`.
+
+## Running locally
+
+### 1. Boot Supabase
+
+```bash
+supabase start
+supabase db reset    # applies supabase/migrations/0000_*.sql and 0001_*.sql
+```
+
+### 2. Create test auth users
+
+In Supabase Studio (`http://127.0.0.1:54323`):
+
+1. Auth → Users → Add user.
+2. Create `operator-a@worksie.test` and `operator-b@worksie.test`.
+3. Copy each user's id (the `auth.users.id` UUID).
+
+### 3. Seed tenant + memberships
+
+Edit `supabase/seed/phase3-auth-fixtures.sql`, paste the two auth UUIDs
+into the `\set auth_a_id` / `\set auth_b_id` lines, then:
+
+```bash
+psql "postgres://postgres:postgres@127.0.0.1:54322/postgres" \
+  -f supabase/seed/phase3-auth-fixtures.sql
+```
+
+### 4. Web app
+
+```bash
+cp .env.example apps/web/.env.local
+# Fill in NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY
+# from `supabase status` output.
+
+pnpm --filter @worksie/web dev
+# Visit http://127.0.0.1:3000/me — middleware will redirect you to /
+# until you sign in (Phase 4 will add the sign-in surface; Phase 3
+# expects the session to be established via the Supabase JS client or
+# Studio's user impersonation flow).
+```
+
+### 5. RLS verification
+
+The harness connects directly to Postgres (not via the Supabase REST
+gateway). You have two options:
+
+**A. Against a running Supabase local stack** — the canonical flow:
+
+```bash
+pnpm --filter @worksie/verify-rls verify
+# Defaults WORKSIE_VERIFY_DATABASE_URL to
+# postgres://postgres:postgres@127.0.0.1:54322/postgres (Supabase CLI).
+```
+
+**B. Against a bare Postgres 16** — useful in CI where booting the full
+Supabase Docker stack is too heavy. The harness only needs `auth.uid()`,
+the `authenticated` role, and the `service_role` role. Apply the stub
+file before the canonical migrations:
+
+```bash
+createdb worksie_verify
+psql -d worksie_verify -v ON_ERROR_STOP=1 \
+  -f scripts/verify-rls/sql/00_supabase_auth_stubs.sql
+psql -d worksie_verify -v ON_ERROR_STOP=1 \
+  -f supabase/migrations/0000_phase_2_canonical_schema.sql
+psql -d worksie_verify -v ON_ERROR_STOP=1 \
+  -f supabase/migrations/0001_phase_2_rls_and_audit.sql
+
+WORKSIE_VERIFY_DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/worksie_verify \
+  pnpm --filter @worksie/verify-rls verify
+```
+
+The harness:
+
+- Default-deny: an unauthenticated `authenticated` session reads zero
+  rows from `work_orders`.
+- Tenant isolation read: User A sees only Tenant A's rows; User B sees
+  only Tenant B's.
+- Tenant isolation write: User A cannot INSERT a customer carrying
+  Tenant B's `tenant_id` (RLS `WITH CHECK` fails).
+- Append-only via RLS: UPDATE/DELETE on `work_order_events` under a
+  foreign tenant returns zero rows (the row is hidden).
+- Append-only via trigger: with RLS bypassed (privileged role), the
+  append-only trigger still raises on UPDATE/DELETE.
+
+A successful run prints `verify-rls: 8/8 passed` and exits 0.
+
+## Security risk analysis
+
+| Risk                                 | Mitigation                                |
+|--------------------------------------|-------------------------------------------|
+| Service-role key in browser bundle   | Separate env reader; only `NEXT_PUBLIC_*` referenced in browser code; transpile boundary stops at `@worksie/auth`. |
+| Cross-tenant read                    | RLS policies (`0001_phase_2_rls_and_audit.sql`) + verified by `scripts/verify-rls`. |
+| Cross-tenant write                   | `WITH CHECK (tenant_id IN ...)` on every policy + verified by harness. |
+| Silent tenant pick across memberships| `resolveTenantContext` errors with `multiple_memberships` until the caller passes an explicit `preferredTenantId`. |
+| `work_order_events` tamper           | RLS hides foreign rows; trigger raises even when RLS is bypassed. |
+| Stale session                        | `middleware.ts` calls `supabase.auth.getUser()` on every request, which rotates an expiring access token via `@supabase/ssr`'s cookie bridge. |
+| First-login bootstrap                | The `no_user_row` branch in the resolver communicates the missing `public.users` row explicitly instead of silently passing as unauthenticated. |
+
+## Issue #25 follow-ups
+
+Phase 3 does not close any of the five hardening items in
+`docs/reviews/PR-23-phase-2-schema.md` §7 / issue #25. Those remain a
+focused hardening pass on a separate branch.

--- a/packages/auth/.eslintrc.cjs
+++ b/packages/auth/.eslintrc.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  extends: ["../config/eslint-preset-node.cjs"]
+};

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@worksie/auth",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./env": "./src/env.ts",
+    "./tenant": "./src/tenant.ts"
+  },
+  "scripts": {
+    "lint": "eslint src --max-warnings 0",
+    "typecheck": "tsc --noEmit",
+    "build": "tsc --noEmit",
+    "clean": "rm -rf dist .turbo node_modules"
+  },
+  "dependencies": {
+    "@worksie/domain": "workspace:*",
+    "@worksie/types": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20.17.6",
+    "@worksie/config": "workspace:*",
+    "eslint": "^8.57.1",
+    "typescript": "^5.6.3"
+  }
+}

--- a/packages/auth/src/env.ts
+++ b/packages/auth/src/env.ts
@@ -1,0 +1,85 @@
+// Supabase environment validation. The web bundle only ever sees the
+// public anon key + URL; the service-role key is intentionally NOT
+// readable from this module so it can never accidentally cross into a
+// client component. A separate `readServiceRoleEnv()` helper is provided
+// for explicit, server-only consumers (RLS verification scripts, future
+// admin tasks).
+
+export type SupabasePublicEnv = {
+  readonly url: string;
+  readonly anonKey: string;
+};
+
+export type SupabaseServiceRoleEnv = {
+  readonly url: string;
+  readonly serviceRoleKey: string;
+};
+
+const URL_PATTERN = /^https?:\/\/[^\s]+$/;
+const JWT_PATTERN = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
+
+function requireString(
+  source: Record<string, string | undefined>,
+  key: string
+): string {
+  const raw = source[key];
+  if (typeof raw !== "string" || raw.trim().length === 0) {
+    throw new Error(
+      `Missing required environment variable: ${key}. ` +
+        "See docs/PHASE_3_AUTH.md for the Supabase env contract."
+    );
+  }
+  return raw.trim();
+}
+
+function assertUrl(value: string, key: string): void {
+  if (!URL_PATTERN.test(value)) {
+    throw new Error(
+      `Environment variable ${key} is not a valid http(s) URL: "${value}".`
+    );
+  }
+}
+
+function assertJwtShape(value: string, key: string): void {
+  if (!JWT_PATTERN.test(value)) {
+    throw new Error(
+      `Environment variable ${key} does not look like a Supabase JWT key. ` +
+        "Expected three base64url segments separated by '.'."
+    );
+  }
+}
+
+// Public env. Safe for the browser bundle. NEXT_PUBLIC_* names are
+// preserved so Next.js's build-time inlining works.
+export function readSupabasePublicEnv(
+  source: Record<string, string | undefined> = readEnvSource()
+): SupabasePublicEnv {
+  const url = requireString(source, "NEXT_PUBLIC_SUPABASE_URL");
+  const anonKey = requireString(source, "NEXT_PUBLIC_SUPABASE_ANON_KEY");
+  assertUrl(url, "NEXT_PUBLIC_SUPABASE_URL");
+  assertJwtShape(anonKey, "NEXT_PUBLIC_SUPABASE_ANON_KEY");
+  return { url, anonKey };
+}
+
+// Service-role env. NEVER call this from code that ships to the browser.
+// The function name is verbose on purpose so a code review can flag it.
+export function readSupabaseServiceRoleEnv(
+  source: Record<string, string | undefined> = readEnvSource()
+): SupabaseServiceRoleEnv {
+  const url = requireString(source, "SUPABASE_URL");
+  const serviceRoleKey = requireString(source, "SUPABASE_SERVICE_ROLE_KEY");
+  assertUrl(url, "SUPABASE_URL");
+  assertJwtShape(serviceRoleKey, "SUPABASE_SERVICE_ROLE_KEY");
+  return { url, serviceRoleKey };
+}
+
+function readEnvSource(): Record<string, string | undefined> {
+  // `process` is available under Node and Next.js server runtimes. The
+  // browser bundler replaces direct `process.env.NEXT_PUBLIC_*` references
+  // with literals, so callers in browser code should pass a literal
+  // record instead of relying on this default.
+  if (typeof process !== "undefined" && process.env) {
+    return process.env as Record<string, string | undefined>;
+  }
+  return {};
+}

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,0 +1,26 @@
+// @worksie/auth — Phase 3 tenant/auth boundary primitives.
+//
+// This package is intentionally transport-free. It exposes:
+//   - typed Supabase env validators (public + service-role kept separate)
+//   - the tenant-context resolver and its error model
+//
+// Web/server callers wire a Supabase client + DB lookups on top of these.
+
+export {
+  readSupabasePublicEnv,
+  readSupabaseServiceRoleEnv,
+  type SupabasePublicEnv,
+  type SupabaseServiceRoleEnv
+} from "./env";
+
+export {
+  resolveTenantContext,
+  describeTenantContextError,
+  type AppUser,
+  type AuthUser,
+  type Membership,
+  type Tenant,
+  type TenantContextErrorReason,
+  type TenantContextInputs,
+  type TenantContextResult
+} from "./tenant";

--- a/packages/auth/src/tenant.ts
+++ b/packages/auth/src/tenant.ts
@@ -1,0 +1,166 @@
+// Tenant context primitives. Pure functions over the canonical
+// `users` + `memberships` rows; transport (Supabase client, DB client,
+// HTTP request) is the caller's concern. This keeps the resolver
+// reusable from the web app, the RLS verification script, and future
+// server actions.
+//
+// Error semantics are explicit:
+//   - `unauthenticated`     → no Supabase session
+//   - `no_user_row`         → session exists but no public.users row yet
+//                             (first-login bootstrap or stale token)
+//   - `no_membership`       → user exists but has zero memberships
+//   - `no_active_membership`→ memberships exist but none are `active`
+//   - `multiple_memberships`→ more than one active membership and the
+//                             caller did not specify a tenant
+//
+// The "multiple_memberships" case is intentionally surfaced as an error
+// rather than picking one. The product needs a deliberate tenant switcher
+// before we silently default someone into the wrong tenant.
+
+import type {
+  MembershipRole,
+  MembershipStatus
+} from "@worksie/domain";
+
+export type AuthUser = {
+  readonly authUserId: string;
+  readonly email: string;
+};
+
+export type AppUser = {
+  readonly id: string;
+  readonly authUserId: string;
+  readonly email: string;
+  readonly displayName: string | null;
+  readonly phone: string | null;
+};
+
+export type Membership = {
+  readonly id: string;
+  readonly tenantId: string;
+  readonly userId: string;
+  readonly role: MembershipRole;
+  readonly status: MembershipStatus;
+};
+
+export type Tenant = {
+  readonly id: string;
+  readonly name: string;
+  readonly timezone: string;
+};
+
+export type TenantContextErrorReason =
+  | "unauthenticated"
+  | "no_user_row"
+  | "no_membership"
+  | "no_active_membership"
+  | "multiple_memberships";
+
+export type TenantContextResult =
+  | {
+      readonly ok: true;
+      readonly authUser: AuthUser;
+      readonly user: AppUser;
+      readonly membership: Membership;
+      readonly tenant: Tenant;
+    }
+  | {
+      readonly ok: false;
+      readonly reason: TenantContextErrorReason;
+      readonly authUser: AuthUser | null;
+      readonly user: AppUser | null;
+      readonly memberships: readonly Membership[];
+    };
+
+export type TenantContextInputs = {
+  readonly authUser: AuthUser | null;
+  readonly user: AppUser | null;
+  readonly memberships: readonly Membership[];
+  // Lookup is supplied by the caller so we don't bind to a particular
+  // DB driver here. May be sync (preloaded cache) or async (live query).
+  readonly loadTenant: (
+    tenantId: string
+  ) => Tenant | null | Promise<Tenant | null>;
+  // Optional caller-supplied tenant pick. When the user has multiple
+  // active memberships the caller may pass the chosen tenant id; if it
+  // matches an active membership we resolve to that one instead of
+  // erroring with `multiple_memberships`.
+  readonly preferredTenantId?: string;
+};
+
+export async function resolveTenantContext(
+  input: TenantContextInputs
+): Promise<TenantContextResult> {
+  const { authUser, user, memberships, loadTenant, preferredTenantId } = input;
+
+  if (!authUser) {
+    return failure("unauthenticated", null, null, []);
+  }
+  if (!user) {
+    return failure("no_user_row", authUser, null, []);
+  }
+  if (memberships.length === 0) {
+    return failure("no_membership", authUser, user, []);
+  }
+
+  const active = memberships.filter((m) => m.status === "active");
+  if (active.length === 0) {
+    return failure("no_active_membership", authUser, user, memberships);
+  }
+
+  let chosen: Membership;
+  if (active.length === 1) {
+    chosen = active[0]!;
+  } else if (preferredTenantId) {
+    const match = active.find((m) => m.tenantId === preferredTenantId);
+    if (!match) {
+      return failure("multiple_memberships", authUser, user, memberships);
+    }
+    chosen = match;
+  } else {
+    return failure("multiple_memberships", authUser, user, memberships);
+  }
+
+  const tenant = await loadTenant(chosen.tenantId);
+  if (!tenant) {
+    // RLS hid the row, or it was deleted between checks. Surface this as
+    // "no_active_membership" — the caller doesn't have access.
+    return failure("no_active_membership", authUser, user, memberships);
+  }
+
+  return {
+    ok: true,
+    authUser,
+    user,
+    membership: chosen,
+    tenant
+  };
+}
+
+function failure(
+  reason: TenantContextErrorReason,
+  authUser: AuthUser | null,
+  user: AppUser | null,
+  memberships: readonly Membership[]
+): TenantContextResult {
+  return { ok: false, reason, authUser, user, memberships };
+}
+
+// Operator-facing summary for the protected status page. Keep this in
+// one place so the wording stays consistent.
+export function describeTenantContextError(
+  reason: TenantContextErrorReason
+): string {
+  switch (reason) {
+    case "unauthenticated":
+      return "Not signed in.";
+    case "no_user_row":
+      return "Signed in, but no Worksie user record exists yet for this account.";
+    case "no_membership":
+      return "Signed in, but this account has no tenant memberships.";
+    case "no_active_membership":
+      return "Signed in, but no active tenant membership.";
+    case "multiple_memberships":
+      return "Signed in with multiple active memberships — tenant must be selected explicitly.";
+  }
+}

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,15 @@ importers:
 
   apps/web:
     dependencies:
+      '@supabase/ssr':
+        specifier: ^0.5.2
+        version: 0.5.2(@supabase/supabase-js@2.105.4)
+      '@supabase/supabase-js':
+        specifier: ^2.46.1
+        version: 2.105.4
+      '@worksie/auth':
+        specifier: workspace:*
+        version: link:../../packages/auth
       '@worksie/domain':
         specifier: workspace:*
         version: link:../../packages/domain
@@ -117,7 +126,29 @@ importers:
         version: 8.5.14
       tailwindcss:
         specifier: ^3.4.15
-        version: 3.4.19
+        version: 3.4.19(tsx@4.22.1)
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+
+  packages/auth:
+    dependencies:
+      '@worksie/domain':
+        specifier: workspace:*
+        version: link:../domain
+      '@worksie/types':
+        specifier: workspace:*
+        version: link:../types
+    devDependencies:
+      '@types/node':
+        specifier: ^20.17.6
+        version: 20.19.41
+      '@worksie/config':
+        specifier: workspace:*
+        version: link:../config
+      eslint:
+        specifier: ^8.57.1
+        version: 8.57.1
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
@@ -191,6 +222,34 @@ importers:
       eslint:
         specifier: ^8.57.1
         version: 8.57.1
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+
+  scripts/verify-rls:
+    dependencies:
+      '@worksie/auth':
+        specifier: workspace:*
+        version: link:../../packages/auth
+      '@worksie/domain':
+        specifier: workspace:*
+        version: link:../../packages/domain
+      postgres:
+        specifier: ^3.4.5
+        version: 3.4.9
+    devDependencies:
+      '@types/node':
+        specifier: ^20.17.6
+        version: 20.19.41
+      '@worksie/config':
+        specifier: workspace:*
+        version: link:../../packages/config
+      eslint:
+        specifier: ^8.57.1
+        version: 8.57.1
+      tsx:
+        specifier: ^4.19.2
+        version: 4.22.1
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
@@ -962,6 +1021,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.18.20':
     resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
     engines: {node: '>=12'}
@@ -971,6 +1036,12 @@ packages:
   '@esbuild/android-arm64@0.19.12':
     resolution: {integrity: sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -986,6 +1057,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.18.20':
     resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
     engines: {node: '>=12'}
@@ -995,6 +1072,12 @@ packages:
   '@esbuild/android-x64@0.19.12':
     resolution: {integrity: sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -1010,6 +1093,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.18.20':
     resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
     engines: {node: '>=12'}
@@ -1019,6 +1108,12 @@ packages:
   '@esbuild/darwin-x64@0.19.12':
     resolution: {integrity: sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -1034,6 +1129,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.18.20':
     resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
     engines: {node: '>=12'}
@@ -1043,6 +1144,12 @@ packages:
   '@esbuild/freebsd-x64@0.19.12':
     resolution: {integrity: sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -1058,6 +1165,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.18.20':
     resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
     engines: {node: '>=12'}
@@ -1067,6 +1180,12 @@ packages:
   '@esbuild/linux-arm@0.19.12':
     resolution: {integrity: sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -1082,6 +1201,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.18.20':
     resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
     engines: {node: '>=12'}
@@ -1091,6 +1216,12 @@ packages:
   '@esbuild/linux-loong64@0.19.12':
     resolution: {integrity: sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==}
     engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -1106,6 +1237,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.18.20':
     resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
     engines: {node: '>=12'}
@@ -1115,6 +1252,12 @@ packages:
   '@esbuild/linux-ppc64@0.19.12':
     resolution: {integrity: sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -1130,6 +1273,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.18.20':
     resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
     engines: {node: '>=12'}
@@ -1139,6 +1288,12 @@ packages:
   '@esbuild/linux-s390x@0.19.12':
     resolution: {integrity: sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==}
     engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
@@ -1154,6 +1309,18 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.18.20':
     resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
     engines: {node: '>=12'}
@@ -1165,6 +1332,18 @@ packages:
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
 
   '@esbuild/openbsd-x64@0.18.20':
     resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
@@ -1178,6 +1357,18 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/sunos-x64@0.18.20':
     resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
     engines: {node: '>=12'}
@@ -1187,6 +1378,12 @@ packages:
   '@esbuild/sunos-x64@0.19.12':
     resolution: {integrity: sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
@@ -1202,6 +1399,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.18.20':
     resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
     engines: {node: '>=12'}
@@ -1214,6 +1417,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.18.20':
     resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
     engines: {node: '>=12'}
@@ -1223,6 +1432,12 @@ packages:
   '@esbuild/win32-x64@0.19.12':
     resolution: {integrity: sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -1759,6 +1974,38 @@ packages:
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
 
+  '@supabase/auth-js@2.105.4':
+    resolution: {integrity: sha512-Ejfa37M5xoIwoxVebxRahnwubPo8g22qkXQ4p50+N9MIvU9UZoN+A8dwVPtczzGf8oV/YXN80ZPxK4aWXuSN/A==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/functions-js@2.105.4':
+    resolution: {integrity: sha512-JVNKbBft3Qkja+WlGaE026AJ2AH9K0UTsxsfvEIHgd4zFrBor4BYRCrYFrv9IDsvVqkF72wKDsODJl5GY/C4tA==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/phoenix@0.4.2':
+    resolution: {integrity: sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A==}
+
+  '@supabase/postgrest-js@2.105.4':
+    resolution: {integrity: sha512-SppIyLo/kTwIlz1qpv2HN1EQqBg0GVktrDDFsXygYROha3MgVn4rT7p5EjFHFqXQm2rdRGb/BI7bc+jr10m91w==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/realtime-js@2.105.4':
+    resolution: {integrity: sha512-6ov6c59+8D9h7q4M4Gy/uDJlC0Akxl9/714Y+6vJ+Sijuc16TS/p5DwhfRCLNcIhNiej1gEt+CQUwsjiPt4PxQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/ssr@0.5.2':
+    resolution: {integrity: sha512-n3plRhr2Bs8Xun1o4S3k1CDv17iH5QY9YcoEvXX3bxV1/5XSasA0mNXYycFmADIdtdE6BG9MRjP5CGIs8qxC8A==}
+    peerDependencies:
+      '@supabase/supabase-js': ^2.43.4
+
+  '@supabase/storage-js@2.105.4':
+    resolution: {integrity: sha512-Jx+pzMP1Whjof2PWHoVBUA75/p7PQE9CqKBzn1oXVyJDOggMLSH2OzVWwsXYaxEpdC1K/KltwmOX44nL3LHl9g==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/supabase-js@2.105.4':
+    resolution: {integrity: sha512-cEnx+k49knU+qdIP7rXwR6fqEXPHZs+74xFK1R0S8MgQ7v9tbePVdGxvO03n3bPympMdJWVLadARBfU4TgNHCQ==}
+    engines: {node: '>=20.0.0'}
+
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
@@ -1809,6 +2056,9 @@ packages:
 
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/cookie@0.6.0':
+    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
 
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
@@ -2533,6 +2783,10 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
   core-js-compat@3.49.0:
     resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
 
@@ -2875,6 +3129,11 @@ packages:
   esbuild@0.19.12:
     resolution: {integrity: sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==}
     engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+    engines: {node: '>=18'}
     hasBin: true
 
   escalade@3.2.0:
@@ -3434,6 +3693,10 @@ packages:
 
   hyphenate-style-name@1.1.0:
     resolution: {integrity: sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==}
+
+  iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -5151,6 +5414,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.22.1:
+    resolution: {integrity: sha512-TvncJykhxAzFCk0VQZKBTClall4Pm7qXDSodb6uxi8QFa8X8mT6ABjxxsQ2opDRYxG7AzcRWXaFtruz5HJKuWg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   turbo@2.9.14:
     resolution: {integrity: sha512-BQqXRr4UoWI3UPFrtznCLykYHxwxWh53iCB57x092jPMjIlW1wnm3N895g5irpiXmnxUhREBB0n6+y8BHhs4nw==}
     hasBin: true
@@ -6421,10 +6689,16 @@ snapshots:
   '@esbuild/aix-ppc64@0.19.12':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
   '@esbuild/android-arm64@0.18.20':
     optional: true
 
   '@esbuild/android-arm64@0.19.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
     optional: true
 
   '@esbuild/android-arm@0.18.20':
@@ -6433,10 +6707,16 @@ snapshots:
   '@esbuild/android-arm@0.19.12':
     optional: true
 
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
   '@esbuild/android-x64@0.18.20':
     optional: true
 
   '@esbuild/android-x64@0.19.12':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
     optional: true
 
   '@esbuild/darwin-arm64@0.18.20':
@@ -6445,10 +6725,16 @@ snapshots:
   '@esbuild/darwin-arm64@0.19.12':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
   '@esbuild/darwin-x64@0.18.20':
     optional: true
 
   '@esbuild/darwin-x64@0.19.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
     optional: true
 
   '@esbuild/freebsd-arm64@0.18.20':
@@ -6457,10 +6743,16 @@ snapshots:
   '@esbuild/freebsd-arm64@0.19.12':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
   '@esbuild/freebsd-x64@0.18.20':
     optional: true
 
   '@esbuild/freebsd-x64@0.19.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
   '@esbuild/linux-arm64@0.18.20':
@@ -6469,10 +6761,16 @@ snapshots:
   '@esbuild/linux-arm64@0.19.12':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
   '@esbuild/linux-arm@0.18.20':
     optional: true
 
   '@esbuild/linux-arm@0.19.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
     optional: true
 
   '@esbuild/linux-ia32@0.18.20':
@@ -6481,10 +6779,16 @@ snapshots:
   '@esbuild/linux-ia32@0.19.12':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
   '@esbuild/linux-loong64@0.18.20':
     optional: true
 
   '@esbuild/linux-loong64@0.19.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
     optional: true
 
   '@esbuild/linux-mips64el@0.18.20':
@@ -6493,10 +6797,16 @@ snapshots:
   '@esbuild/linux-mips64el@0.19.12':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
   '@esbuild/linux-ppc64@0.18.20':
     optional: true
 
   '@esbuild/linux-ppc64@0.19.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
   '@esbuild/linux-riscv64@0.18.20':
@@ -6505,10 +6815,16 @@ snapshots:
   '@esbuild/linux-riscv64@0.19.12':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
   '@esbuild/linux-s390x@0.18.20':
     optional: true
 
   '@esbuild/linux-s390x@0.19.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
     optional: true
 
   '@esbuild/linux-x64@0.18.20':
@@ -6517,10 +6833,22 @@ snapshots:
   '@esbuild/linux-x64@0.19.12':
     optional: true
 
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    optional: true
+
   '@esbuild/netbsd-x64@0.18.20':
     optional: true
 
   '@esbuild/netbsd-x64@0.19.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/openbsd-x64@0.18.20':
@@ -6529,10 +6857,19 @@ snapshots:
   '@esbuild/openbsd-x64@0.19.12':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    optional: true
+
   '@esbuild/sunos-x64@0.18.20':
     optional: true
 
   '@esbuild/sunos-x64@0.19.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.0':
     optional: true
 
   '@esbuild/win32-arm64@0.18.20':
@@ -6541,16 +6878,25 @@ snapshots:
   '@esbuild/win32-arm64@0.19.12':
     optional: true
 
+  '@esbuild/win32-arm64@0.28.0':
+    optional: true
+
   '@esbuild/win32-ia32@0.18.20':
     optional: true
 
   '@esbuild/win32-ia32@0.19.12':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
   '@esbuild/win32-x64@0.18.20':
     optional: true
 
   '@esbuild/win32-x64@0.19.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@8.57.1)':
@@ -7441,6 +7787,44 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
+  '@supabase/auth-js@2.105.4':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/functions-js@2.105.4':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/phoenix@0.4.2': {}
+
+  '@supabase/postgrest-js@2.105.4':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/realtime-js@2.105.4':
+    dependencies:
+      '@supabase/phoenix': 0.4.2
+      tslib: 2.8.1
+
+  '@supabase/ssr@0.5.2(@supabase/supabase-js@2.105.4)':
+    dependencies:
+      '@supabase/supabase-js': 2.105.4
+      '@types/cookie': 0.6.0
+      cookie: 0.7.2
+
+  '@supabase/storage-js@2.105.4':
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+
+  '@supabase/supabase-js@2.105.4':
+    dependencies:
+      '@supabase/auth-js': 2.105.4
+      '@supabase/functions-js': 2.105.4
+      '@supabase/postgrest-js': 2.105.4
+      '@supabase/realtime-js': 2.105.4
+      '@supabase/storage-js': 2.105.4
+
   '@swc/counter@0.1.3': {}
 
   '@swc/helpers@0.5.13':
@@ -7490,6 +7874,8 @@ snapshots:
   '@types/babel__traverse@7.28.0':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@types/cookie@0.6.0': {}
 
   '@types/graceful-fs@4.1.9':
     dependencies:
@@ -8290,6 +8676,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie@0.7.2: {}
+
   core-js-compat@3.49.0:
     dependencies:
       browserslist: 4.28.2
@@ -8648,6 +9036,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.19.12
       '@esbuild/win32-x64': 0.19.12
 
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
+
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
@@ -8663,7 +9080,7 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 8.59.3(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/parser': 8.59.3(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-expo: 0.1.4(eslint@8.57.1)(typescript@5.9.3)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
@@ -8682,7 +9099,7 @@ snapshots:
       '@typescript-eslint/parser': 8.59.3(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
@@ -8702,7 +9119,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -8717,14 +9134,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.59.3(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -8748,7 +9165,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -9375,6 +9792,8 @@ snapshots:
   human-signals@2.1.0: {}
 
   hyphenate-style-name@1.1.0: {}
+
+  iceberg-js@0.8.1: {}
 
   ieee754@1.2.1: {}
 
@@ -10440,12 +10859,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.14
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.14):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.14)(tsx@4.22.1):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
       postcss: 8.5.14
+      tsx: 4.22.1
 
   postcss-nested@6.2.0(postcss@8.5.14):
     dependencies:
@@ -11191,7 +11611,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  tailwindcss@3.4.19:
+  tailwindcss@3.4.19(tsx@4.22.1):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -11210,7 +11630,7 @@ snapshots:
       postcss: 8.5.14
       postcss-import: 15.1.0(postcss@8.5.14)
       postcss-js: 4.1.0(postcss@8.5.14)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.14)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.14)(tsx@4.22.1)
       postcss-nested: 6.2.0(postcss@8.5.14)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.12
@@ -11301,6 +11721,12 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tsx@4.22.1:
+    dependencies:
+      esbuild: 0.28.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   turbo@2.9.14:
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - "apps/*"
   - "packages/*"
+  - "scripts/*"

--- a/scripts/verify-rls/.eslintrc.cjs
+++ b/scripts/verify-rls/.eslintrc.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  extends: ["../../packages/config/eslint-preset-node.cjs"]
+};

--- a/scripts/verify-rls/package.json
+++ b/scripts/verify-rls/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@worksie/verify-rls",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "verify": "tsx src/index.ts",
+    "lint": "eslint src --max-warnings 0",
+    "typecheck": "tsc --noEmit",
+    "build": "tsc --noEmit",
+    "clean": "rm -rf .turbo node_modules"
+  },
+  "dependencies": {
+    "@worksie/auth": "workspace:*",
+    "@worksie/domain": "workspace:*",
+    "postgres": "^3.4.5"
+  },
+  "devDependencies": {
+    "@types/node": "^20.17.6",
+    "@worksie/config": "workspace:*",
+    "eslint": "^8.57.1",
+    "tsx": "^4.19.2",
+    "typescript": "^5.6.3"
+  }
+}

--- a/scripts/verify-rls/sql/00_supabase_auth_stubs.sql
+++ b/scripts/verify-rls/sql/00_supabase_auth_stubs.sql
@@ -1,0 +1,40 @@
+-- Supabase auth surface stubs for local RLS verification.
+--
+-- The canonical migrations depend on:
+--   - auth.uid()         (returns the current JWT 'sub' claim)
+--   - role `authenticated`
+--   - role `service_role`
+--
+-- A real Supabase project provides these. For a plain Postgres used in
+-- CI / local verification we stub them faithfully enough that the RLS
+-- policies behave identically to a real environment.
+
+CREATE SCHEMA IF NOT EXISTS auth;
+
+-- Roles. `service_role` is created but the verify-rls script never
+-- switches to it — it stays on the superuser to bypass RLS for seeding
+-- and assertion-time queries that need to see across tenants.
+DO $$ BEGIN
+  CREATE ROLE authenticated;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN
+  CREATE ROLE service_role;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- auth.uid(): read the `sub` claim from the request GUC. Mirrors the
+-- behaviour Supabase's GoTrue layer injects via PostgREST.
+CREATE OR REPLACE FUNCTION auth.uid()
+RETURNS uuid
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT NULLIF(current_setting('request.jwt.claim.sub', true), '')::uuid
+$$;
+
+-- Allow `authenticated` to use the public schema and read tables. RLS
+-- still gates row visibility — these grants are required so policy
+-- predicates can even be evaluated.
+GRANT USAGE ON SCHEMA public TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO authenticated;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO authenticated;

--- a/scripts/verify-rls/src/index.ts
+++ b/scripts/verify-rls/src/index.ts
@@ -1,0 +1,335 @@
+// RLS verification harness for Phase 3.
+//
+// What this script proves:
+//   1. Default-deny: an unauthenticated session (no JWT claim) sees zero
+//      rows from any tenant table.
+//   2. Tenant isolation read: User A under `authenticated` sees their own
+//      tenant's rows but NOT another tenant's rows.
+//   3. Tenant isolation write: User A cannot INSERT a row carrying a
+//      foreign tenant_id.
+//   4. work_order_events append-only: UPDATE/DELETE under `authenticated`
+//      are silently filtered to zero rows by RLS, AND a privileged path
+//      (RLS bypassed via `LOCAL` GUC reset) still raises the append-only
+//      trigger.
+//
+// Approach: we connect to local Postgres with a privileged user, seed
+// two minimal tenants + users + memberships + a work_order each, then
+// switch role to `authenticated` and impersonate each user via
+// `SET LOCAL request.jwt.claim.sub`. This mirrors what Supabase does
+// for an authenticated REST request.
+//
+// Pre-reqs:
+//   - `supabase start` succeeded locally
+//   - `supabase db reset` applied 0000 + 0001
+//   - DATABASE_URL points at the local Postgres (defaults to the
+//     Supabase CLI's standard URL).
+
+import { randomUUID } from "node:crypto";
+import postgres from "postgres";
+
+const DATABASE_URL =
+  process.env.WORKSIE_VERIFY_DATABASE_URL ??
+  process.env.SUPABASE_DB_URL ??
+  "postgres://postgres:postgres@127.0.0.1:54322/postgres";
+
+type Probe = { name: string; passed: boolean; detail?: string };
+
+const probes: Probe[] = [];
+
+function record(name: string, passed: boolean, detail?: string): void {
+  probes.push({ name, passed, detail });
+  const status = passed ? "PASS" : "FAIL";
+  // eslint-disable-next-line no-console
+  console.log(`[${status}] ${name}${detail ? ` — ${detail}` : ""}`);
+}
+
+async function main(): Promise<void> {
+  const sql = postgres(DATABASE_URL, {
+    prepare: false,
+    onnotice: () => {}
+  });
+
+  try {
+    await runProbes(sql);
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+
+  const failed = probes.filter((p) => !p.passed);
+  // eslint-disable-next-line no-console
+  console.log(
+    `\nverify-rls: ${probes.length - failed.length}/${probes.length} passed`
+  );
+  if (failed.length > 0) {
+    process.exit(1);
+  }
+}
+
+type Seed = {
+  tenantA: string;
+  tenantB: string;
+  userAId: string;
+  userBId: string;
+  authAId: string;
+  authBId: string;
+  customerAId: string;
+  customerBId: string;
+  serviceAId: string;
+  serviceBId: string;
+  workOrderAId: string;
+  workOrderBId: string;
+  eventAId: string;
+};
+
+async function runProbes(sql: postgres.Sql): Promise<void> {
+  const seed = await seedTwoTenants(sql);
+
+  // ---- Probe 1: default-deny when unauthenticated ----------------------
+  await sql.begin(async (tx) => {
+    await tx.unsafe("SET LOCAL ROLE authenticated");
+    await tx.unsafe("SET LOCAL request.jwt.claim.sub TO ''");
+    const rows = await tx<{ count: number }[]>`
+      SELECT count(*)::int AS count FROM work_orders
+    `;
+    const count = rows[0]?.count ?? -1;
+    record(
+      "unauthenticated default-deny on work_orders",
+      count === 0,
+      `count=${count}`
+    );
+  });
+
+  // ---- Probe 2: A sees A, A does not see B ----------------------------
+  await sql.begin(async (tx) => {
+    await tx.unsafe("SET LOCAL ROLE authenticated");
+    await tx.unsafe(`SET LOCAL request.jwt.claim.sub TO '${seed.authAId}'`);
+    const rows = await tx<
+      { id: string; tenant_id: string }[]
+    >`SELECT id, tenant_id FROM work_orders`;
+    const onlyA = rows.every((r) => r.tenant_id === seed.tenantA);
+    const sawA = rows.some((r) => r.id === seed.workOrderAId);
+    const sawB = rows.some((r) => r.id === seed.workOrderBId);
+    record(
+      "user A sees own tenant's work_orders",
+      onlyA && sawA && !sawB,
+      `rows=${rows.length} sawA=${sawA} sawB=${sawB}`
+    );
+  });
+
+  // ---- Probe 3: B sees B only -----------------------------------------
+  await sql.begin(async (tx) => {
+    await tx.unsafe("SET LOCAL ROLE authenticated");
+    await tx.unsafe(`SET LOCAL request.jwt.claim.sub TO '${seed.authBId}'`);
+    const rows = await tx<
+      { id: string; tenant_id: string }[]
+    >`SELECT id, tenant_id FROM work_orders`;
+    const onlyB = rows.every((r) => r.tenant_id === seed.tenantB);
+    record(
+      "user B sees own tenant's work_orders",
+      onlyB && rows.length === 1,
+      `rows=${rows.length}`
+    );
+  });
+
+  // ---- Probe 4: A cannot INSERT a customer under tenant B -------------
+  // The expected failure aborts the surrounding transaction, so we wrap
+  // the INSERT in a savepoint. The savepoint rollback contains the
+  // failure while the outer transaction commits cleanly.
+  let crossTenantInsertBlocked = false;
+  let crossTenantInsertDetail = "";
+  await sql.begin(async (tx) => {
+    await tx.unsafe("SET LOCAL ROLE authenticated");
+    await tx.unsafe(`SET LOCAL request.jwt.claim.sub TO '${seed.authAId}'`);
+    try {
+      await tx.savepoint(async (sp) => {
+        await sp`
+          INSERT INTO customers (id, tenant_id, name)
+          VALUES (${randomUUID()}, ${seed.tenantB}, 'cross-tenant attempt')
+        `;
+      });
+      crossTenantInsertDetail = "insert unexpectedly succeeded";
+    } catch (e) {
+      crossTenantInsertBlocked = true;
+      crossTenantInsertDetail = (e as Error).message.split("\n")[0] ?? "";
+    }
+  });
+  record(
+    "user A cannot INSERT into tenant B",
+    crossTenantInsertBlocked,
+    crossTenantInsertDetail
+  );
+
+  // ---- Probe 5: append-only via RLS — UPDATE/DELETE return zero rows --
+  await sql.begin(async (tx) => {
+    await tx.unsafe("SET LOCAL ROLE authenticated");
+    await tx.unsafe(`SET LOCAL request.jwt.claim.sub TO '${seed.authBId}'`);
+    // User B tries to UPDATE user A's event. RLS hides the row, so the
+    // statement should affect zero rows (no exception).
+    const updated = await tx`
+      UPDATE work_order_events
+         SET reason = 'tamper'
+       WHERE id = ${seed.eventAId}
+    `;
+    record(
+      "work_order_events UPDATE under wrong tenant affects 0 rows",
+      updated.count === 0,
+      `count=${updated.count}`
+    );
+    const deleted = await tx`
+      DELETE FROM work_order_events WHERE id = ${seed.eventAId}
+    `;
+    record(
+      "work_order_events DELETE under wrong tenant affects 0 rows",
+      deleted.count === 0,
+      `count=${deleted.count}`
+    );
+  });
+
+  // ---- Probe 6: append-only — even with RLS bypassed, trigger raises --
+  // Same savepoint pattern as probe 4: the trigger's RAISE EXCEPTION
+  // would otherwise abort the outer transaction.
+  let triggerRaised = false;
+  let triggerDetail = "";
+  await sql.begin(async (tx) => {
+    // Stay on the privileged role (no SET LOCAL ROLE). RLS does not
+    // apply, but the append-only trigger must still fire.
+    try {
+      await tx.savepoint(async (sp) => {
+        await sp`
+          UPDATE work_order_events SET reason = 'tamper' WHERE id = ${seed.eventAId}
+        `;
+      });
+    } catch (e) {
+      triggerRaised = true;
+      triggerDetail = (e as Error).message.split("\n")[0] ?? "";
+    }
+  });
+  record(
+    "work_order_events append-only trigger raises on UPDATE",
+    triggerRaised,
+    triggerDetail
+  );
+
+  triggerRaised = false;
+  triggerDetail = "";
+  await sql.begin(async (tx) => {
+    try {
+      await tx.savepoint(async (sp) => {
+        await sp`DELETE FROM work_order_events WHERE id = ${seed.eventAId}`;
+      });
+    } catch (e) {
+      triggerRaised = true;
+      triggerDetail = (e as Error).message.split("\n")[0] ?? "";
+    }
+  });
+  record(
+    "work_order_events append-only trigger raises on DELETE",
+    triggerRaised,
+    triggerDetail
+  );
+
+  // Cleanup: drop the seed rows so reruns are idempotent.
+  await cleanup(sql, seed);
+}
+
+async function seedTwoTenants(sql: postgres.Sql): Promise<Seed> {
+  const seed: Seed = {
+    tenantA: randomUUID(),
+    tenantB: randomUUID(),
+    userAId: randomUUID(),
+    userBId: randomUUID(),
+    authAId: randomUUID(),
+    authBId: randomUUID(),
+    customerAId: randomUUID(),
+    customerBId: randomUUID(),
+    serviceAId: randomUUID(),
+    serviceBId: randomUUID(),
+    workOrderAId: randomUUID(),
+    workOrderBId: randomUUID(),
+    eventAId: randomUUID()
+  };
+
+  await sql.begin(async (tx) => {
+    await tx`
+      INSERT INTO tenants (id, name, timezone)
+      VALUES
+        (${seed.tenantA}, ${"verify-rls-A"}, ${"UTC"}),
+        (${seed.tenantB}, ${"verify-rls-B"}, ${"UTC"})
+    `;
+    await tx`
+      INSERT INTO users (id, auth_user_id, email)
+      VALUES
+        (${seed.userAId}, ${seed.authAId}, ${`verify-rls-a+${seed.userAId}@example.test`}),
+        (${seed.userBId}, ${seed.authBId}, ${`verify-rls-b+${seed.userBId}@example.test`})
+    `;
+    await tx`
+      INSERT INTO memberships (tenant_id, user_id, role, status)
+      VALUES
+        (${seed.tenantA}, ${seed.userAId}, 'operator', 'active'),
+        (${seed.tenantB}, ${seed.userBId}, 'operator', 'active')
+    `;
+    await tx`
+      INSERT INTO customers (id, tenant_id, name)
+      VALUES
+        (${seed.customerAId}, ${seed.tenantA}, ${"customer-A"}),
+        (${seed.customerBId}, ${seed.tenantB}, ${"customer-B"})
+    `;
+    await tx`
+      INSERT INTO service_definitions (id, tenant_id, name, category)
+      VALUES
+        (${seed.serviceAId}, ${seed.tenantA}, ${"service-A"}, ${"ramp_install"}),
+        (${seed.serviceBId}, ${seed.tenantB}, ${"service-B"}, ${"ramp_install"})
+    `;
+    await tx`
+      INSERT INTO work_orders (
+        id, tenant_id, service_definition_id, service_snapshot_json,
+        customer_id, status
+      )
+      VALUES
+        (
+          ${seed.workOrderAId}, ${seed.tenantA}, ${seed.serviceAId},
+          ${tx.json({ snapshot: "A" })}, ${seed.customerAId}, 'draft'
+        ),
+        (
+          ${seed.workOrderBId}, ${seed.tenantB}, ${seed.serviceBId},
+          ${tx.json({ snapshot: "B" })}, ${seed.customerBId}, 'draft'
+        )
+    `;
+    await tx`
+      INSERT INTO work_order_events (
+        id, tenant_id, work_order_id, to_state, source
+      )
+      VALUES (
+        ${seed.eventAId}, ${seed.tenantA}, ${seed.workOrderAId},
+        'draft', 'system'
+      )
+    `;
+  });
+
+  return seed;
+}
+
+async function cleanup(sql: postgres.Sql, seed: Seed): Promise<void> {
+  // work_order_events has an append-only trigger plus cascade from
+  // work_orders. We disable user triggers for the teardown transaction
+  // so the seed can be removed cleanly. This requires superuser, which
+  // the local Supabase postgres role has by default. It does NOT change
+  // the trigger's protection for normal application traffic.
+  await sql.begin(async (tx) => {
+    await tx.unsafe("SET LOCAL session_replication_role = replica");
+    await tx`DELETE FROM payout_lines WHERE tenant_id IN (${seed.tenantA}, ${seed.tenantB})`;
+    await tx`DELETE FROM work_order_events WHERE tenant_id IN (${seed.tenantA}, ${seed.tenantB})`;
+    await tx`DELETE FROM work_orders WHERE id IN (${seed.workOrderAId}, ${seed.workOrderBId})`;
+    await tx`DELETE FROM service_definitions WHERE id IN (${seed.serviceAId}, ${seed.serviceBId})`;
+    await tx`DELETE FROM customers WHERE id IN (${seed.customerAId}, ${seed.customerBId})`;
+    await tx`DELETE FROM memberships WHERE user_id IN (${seed.userAId}, ${seed.userBId})`;
+    await tx`DELETE FROM users WHERE id IN (${seed.userAId}, ${seed.userBId})`;
+    await tx`DELETE FROM tenants WHERE id IN (${seed.tenantA}, ${seed.tenantB})`;
+  });
+}
+
+main().catch((err) => {
+  // eslint-disable-next-line no-console
+  console.error("verify-rls failed:", err);
+  process.exit(1);
+});

--- a/scripts/verify-rls/tsconfig.json
+++ b/scripts/verify-rls/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/supabase/seed/phase3-auth-fixtures.sql
+++ b/supabase/seed/phase3-auth-fixtures.sql
@@ -1,0 +1,51 @@
+-- Phase 3 local-only auth fixtures.
+--
+-- Creates two operator-tenant pairs you can sign into via the Supabase
+-- local dashboard's "Authentication → Users → Invite user" flow. After
+-- you create an auth.users row by email, paste its id below and run
+-- this file with `psql` against the local Supabase Postgres.
+--
+-- DO NOT run this in production. It hardcodes test emails and uses
+-- deterministic UUIDs so reruns are idempotent.
+--
+-- Usage:
+--   1. supabase start
+--   2. supabase db reset            # applies 0000 + 0001
+--   3. Create two test users in Supabase Studio (or supabase auth admin):
+--        operator-a@worksie.test
+--        operator-b@worksie.test
+--      Copy each user's id (auth.users.id).
+--   4. Replace the placeholders below and run:
+--        psql "$WORKSIE_VERIFY_DATABASE_URL" -f supabase/seed/phase3-auth-fixtures.sql
+
+-- ---- Replace these two before running. -----------------------------------
+\set auth_a_id   '00000000-0000-0000-0000-000000000001'
+\set auth_b_id   '00000000-0000-0000-0000-000000000002'
+
+-- Deterministic Worksie ids so the seed is rerunnable.
+\set tenant_a    'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+\set tenant_b    'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
+\set user_a      'a1111111-1111-1111-1111-111111111111'
+\set user_b      'b1111111-1111-1111-1111-111111111111'
+
+BEGIN;
+
+INSERT INTO tenants (id, name, timezone)
+VALUES
+  (:'tenant_a', 'Acme Ramps', 'America/Chicago'),
+  (:'tenant_b', 'Sunbelt Lifts', 'America/Denver')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO users (id, auth_user_id, email, display_name)
+VALUES
+  (:'user_a', :'auth_a_id', 'operator-a@worksie.test', 'Operator A'),
+  (:'user_b', :'auth_b_id', 'operator-b@worksie.test', 'Operator B')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO memberships (tenant_id, user_id, role, status)
+VALUES
+  (:'tenant_a', :'user_a', 'operator', 'active'),
+  (:'tenant_b', :'user_b', 'operator', 'active')
+ON CONFLICT (tenant_id, user_id) DO NOTHING;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Phase 3 implementation — minimal tenant/auth boundary on top of the canonical 21-entity Drizzle schema from PR #23. Boundary-only: no product UI, no work-order workflows, no payout execution, no Stripe/Resend/Twilio, no PowerSync, no schema changes.

## What landed

- **`@worksie/auth`** — transport-free package
  - `readSupabasePublicEnv()` / `readSupabaseServiceRoleEnv()` on separate, deliberately-named entry points so a code review can flag the server-only helper if it ever appears in a client component.
  - `resolveTenantContext()` with an explicit error model: `unauthenticated`, `no_user_row`, `no_membership`, `no_active_membership`, `multiple_memberships`. The multi-membership case is an *error*, not a silent pick — Phase 4 will add an explicit tenant switcher.

- **`apps/web` Supabase wiring** via `@supabase/ssr`
  - `lib/supabase/browser.ts` (client) and `lib/supabase/server.ts` (server component) with the cookie bridge.
  - `src/middleware.ts` calls `supabase.auth.getUser()` on every request to rotate access-token cookies, and gates `/me` against unauthenticated visitors.
  - `app/me/page.tsx` server component renders the resolver's output — no mutations, no product surface.
  - `app/page.tsx` shows a redirect notice when middleware sends an unauthenticated visitor back from `/me`.

- **`scripts/verify-rls`** standalone harness (`tsx` + `postgres`)
  - 8 probes: default-deny / tenant isolation read (A and B) / tenant isolation write (cross-tenant INSERT rejected) / `work_order_events` UPDATE+DELETE under wrong tenant filtered to 0 rows by RLS / append-only trigger raises on UPDATE+DELETE when RLS is bypassed.
  - Runs against Supabase CLI's local Postgres **or** bare PG 16 with `sql/00_supabase_auth_stubs.sql` applied first (CI-friendly).
  - Idempotent: cleanup disables `session_replication_role` for teardown so the `work_order_events` append-only trigger doesn't block removal of seed rows.

- **Docs + fixtures**
  - `docs/PHASE_3_AUTH.md` — architecture, env contract, error model, local-dev steps, RLS verification, security risk analysis.
  - `.env.example` — public + server-only env keys clearly separated.
  - `supabase/seed/phase3-auth-fixtures.sql` — two operator-tenant pairs for local sign-in testing.

## What did NOT change

- Canonical 21-entity schema in `packages/db/src/schema/` — untouched.
- `supabase/migrations/0000_*.sql` and `0001_*.sql` — untouched.
- No new entities, no table renames, no migration drift.
- Issue #25 hardening items (RLS migration idempotency, trigger `search_path`, payout-line append-only at DB, etc.) — all five remain deferred to a dedicated hardening pass.

## Validation

| Command | Result |
| --- | --- |
| `pnpm lint` | ✅ green |
| `pnpm typecheck` | ✅ green |
| `pnpm build` | ✅ green (`/`, `/healthz`, `/me`, middleware 86.5 kB) |
| `pnpm --filter @worksie/verify-rls verify` | ✅ 8/8 passed, twice in a row (idempotent cleanup) |
| Service-role key grep on `.next/static` | 0 hits |
| Firebase references outside deprecated/history docs | 0 hits |

## RLS verification — full probe output

```
[PASS] unauthenticated default-deny on work_orders — count=0
[PASS] user A sees own tenant's work_orders — rows=1 sawA=true sawB=false
[PASS] user B sees own tenant's work_orders — rows=1
[PASS] user A cannot INSERT into tenant B — new row violates row-level security policy for table "customers"
[PASS] work_order_events UPDATE under wrong tenant affects 0 rows — count=0
[PASS] work_order_events DELETE under wrong tenant affects 0 rows — count=0
[PASS] work_order_events append-only trigger raises on UPDATE — work_order_events is append-only (canonical audit log)
[PASS] work_order_events append-only trigger raises on DELETE — work_order_events is append-only (canonical audit log)

verify-rls: 8/8 passed
```

## Test plan

- [x] `pnpm lint` green
- [x] `pnpm typecheck` green
- [x] `pnpm build` green; `/me` appears as a `ƒ` (dynamic) route; middleware compiles
- [x] `pnpm --filter @worksie/verify-rls verify` 8/8 passing against bare PG 16 with stubs
- [x] Service-role key absent from client bundle (`grep -rE 'SUPABASE_SERVICE_ROLE_KEY|readSupabaseServiceRoleEnv' apps/web/.next/static` → 0 matches)
- [x] No new entities, no table renames, no migration drift
- [ ] *Manual* — sign in via Supabase Studio after `supabase start`, visit `/me`, confirm tenant resolves
- [ ] *Manual* — visit `/me` while signed out, confirm redirect to `/?notice=signin_required`

## Files changed

19 new files, 6 modified. No deletions.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PMhAFesGJg1kfuZTYEpRps)_