### PR TITLE
Add competitive positioning addendum and update spine/PRD/README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ safety, documentation, proof-of-work, and 1099 payout.
 | [`docs/WORKSIE_SPINE.md`](docs/WORKSIE_SPINE.md) | Product identity, doctrine, canonical stack |
 | [`docs/PRD.md`](docs/PRD.md) | Personas, top-level flows, v1 scope |
 | [`docs/DOMAIN_MODEL.md`](docs/DOMAIN_MODEL.md) | Entities, relationships, hard rules |
+| [`docs/COMPETITIVE_POSITIONING.md`](docs/COMPETITIVE_POSITIONING.md) | Market gap, positioning, MVP wedge, moat strategy |
 | [`docs/TECH_STACK_DECISION.md`](docs/TECH_STACK_DECISION.md) | Why Supabase + Next.js + Expo + PowerSync |
 | [`docs/OFFLINE_FIRST_ARCHITECTURE.md`](docs/OFFLINE_FIRST_ARCHITECTURE.md) | Sync classes, conflict rules, upload queue |
 | [`docs/ONBOARDING_FLOWS.md`](docs/ONBOARDING_FLOWS.md) | Tenant and contractor onboarding, compliance gate |

--- a/docs/COMPETITIVE_POSITIONING.md
+++ b/docs/COMPETITIVE_POSITIONING.md
@@ -1,0 +1,123 @@
+# Competitive Positioning
+
+Worksie's product strategy is to own the operational readiness layer for
+field-service and contractor operations. This document defines the market gap,
+buyer-facing language, product boundaries, and moat strategy that other product
+and architecture decisions must reinforce.
+
+## Strategic Position
+
+Worksie is not a CRM, scheduling platform, accounting tool, generic form
+builder, or photo documentation app.
+
+Worksie is the **operational readiness layer** for field-service and contractor
+operations.
+
+The product exists to answer one critical operational question:
+
+> Is this field job complete, documented, approved, and ready to bill?
+
+## Market Gap
+
+Existing tools own adjacent layers:
+
+- CompanyCam owns photo documentation.
+- SimplyWise owns contractor admin and receipt/expense workflows.
+- Jobber and Housecall Pro own scheduling, quoting, and invoicing.
+- ServiceTitan owns enterprise field-service operations.
+- SafetyCulture owns inspections and checklists.
+- QuickBooks and Xero own accounting.
+
+No SMB-to-mid-market platform clearly owns the validation layer between field
+activity and downstream business systems.
+
+Worksie should occupy this gap.
+
+## Core Differentiator
+
+Worksie converts raw field activity into:
+
+- validated job records
+- documentation completeness scores
+- missing evidence flags
+- approval-ready submissions
+- billing readiness status
+- operational memory
+- downstream automation triggers
+
+## Buyer-Facing Positioning
+
+Primary positioning:
+
+> Worksie helps field teams prove the job is complete, approved, and ready to bill.
+
+Secondary positioning:
+
+> Worksie is the operational readiness engine between field execution and your
+> CRM, accounting, and business systems.
+
+## MVP Wedge
+
+The initial wedge should focus on documentation-heavy contractor and inspection
+workflows where incomplete documentation delays payment, approvals, compliance,
+or customer acceptance.
+
+Priority verticals:
+
+1. restoration contractors
+2. commercial inspection teams
+3. specialty contractors
+4. maintenance and service teams with approval-heavy workflows
+
+## Product Boundary
+
+Worksie should integrate with CRMs, accounting platforms, and scheduling tools
+rather than replace them.
+
+Worksie owns:
+
+- field proof capture
+- dynamic submission workflows
+- readiness scoring
+- approval routing
+- billing readiness
+- operational memory
+- automation triggers
+
+Worksie does not own:
+
+- lead pipelines
+- sales CRM
+- marketing automation
+- full accounting
+- payroll
+- inventory
+- dispatch as a core MVP feature
+
+## Moat Strategy
+
+Worksie's moat should be built through:
+
+1. Operational memory
+2. Tenant-specific workflow rules
+3. Documentation completeness data
+4. Approval and billing-readiness patterns
+5. Integration into downstream CRM/accounting systems
+6. Vertical-specific evidence standards
+
+The strongest long-term moat is operational memory: every job record teaches
+Worksie what complete, billable, and approval-ready work looks like for that
+tenant and vertical.
+
+## MVP Product Rule
+
+Every MVP feature must support one of the following outcomes:
+
+- capture what happened
+- validate whether documentation is complete
+- route approval
+- determine billing readiness
+- create audit evidence
+- trigger downstream systems
+
+If a feature does not support one of these outcomes, it should be deferred.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -14,6 +14,20 @@ and `DOMAIN_MODEL.md` (entities).
 - **Customer** — receives the service. Limited surface area in v1: signs a
   completion form, may view a job summary.
 
+## Product Focus
+
+Worksie helps field teams prove a job is complete, approved, and ready to
+bill. The MVP focuses on documentation-heavy contractor and inspection
+workflows where incomplete proof delays payment, approvals, compliance, or
+customer acceptance. Priority verticals are restoration contractors, commercial
+inspection teams, specialty contractors, and maintenance or service teams with
+approval-heavy workflows.
+
+Every v1 feature must support at least one readiness outcome: capture what
+happened, validate documentation completeness, route approval, determine billing
+readiness, create audit evidence, or trigger downstream systems. Features that
+do not support one of those outcomes are deferred.
+
 ## Top-Level Flows (v1)
 
 1. **Business configuration.** Operator defines services, required gear,
@@ -48,6 +62,11 @@ and `DOMAIN_MODEL.md` (entities).
 
 ## Explicitly Out of Scope (v1)
 
+- Lead pipelines, sales CRM, and marketing automation. Worksie integrates with
+  CRM systems rather than replacing them.
+- Full accounting, payroll, and inventory. Worksie determines readiness and
+  emits downstream triggers, but accounting systems remain the ledger.
+- Dispatch as a core MVP feature beyond assignment and notification hooks.
 - Real-time chat. Notifications only.
 - 3D LiDAR scanning. Reserved for later.
 - AI-generated narrative reports. Reserved for later.

--- a/docs/WORKSIE_SPINE.md
+++ b/docs/WORKSIE_SPINE.md
@@ -12,8 +12,11 @@ what it sells, and it produces field-ready execution from that model:
 onboarding, dispatch, work orders, safety, documentation, proof-of-work, and
 1099 payout.
 
-Worksie is **not** another CRM or another photo log. The previous framing
-("outpace CompanyCam") is retired.
+Worksie is **not** another CRM, scheduling platform, accounting tool, generic
+form builder, or photo documentation app. The previous framing ("outpace
+CompanyCam") is retired. Worksie owns the operational readiness layer between
+field execution and downstream business systems: the answer to whether a field
+job is complete, documented, approved, and ready to bill.
 
 ## Who Worksie Serves
 
@@ -48,6 +51,10 @@ them.
    safety acknowledgements are modeled, expirable, and gating.
 7. **1099 payout is a workflow, not a spreadsheet.** Piece-rate and
    completion-based invoicing must be derivable from work orders.
+8. **Readiness is the product boundary.** Worksie integrates with CRMs,
+   accounting, scheduling, and dispatch systems rather than replacing them; it
+   owns proof capture, completeness validation, approval routing, billing
+   readiness, operational memory, and downstream automation triggers.
 
 ## Canonical Stack
 
@@ -101,6 +108,8 @@ Worksie must generalize beyond this pack, but it must work cleanly for it.
 - `docs/WORKSIE_SPINE.md` — this file. Product identity, doctrine, stack.
 - `docs/PRD.md` — product requirements at the user-flow level.
 - `docs/DOMAIN_MODEL.md` — entities, relationships, lifecycle.
+- `docs/COMPETITIVE_POSITIONING.md` — market gap, buyer-facing language,
+  MVP wedge, product boundaries, and moat strategy.
 - `docs/TECH_STACK_DECISION.md` — stack rationale and trade-offs.
 - `docs/OFFLINE_FIRST_ARCHITECTURE.md` — sync model, conflict rules.
 - `docs/ONBOARDING_FLOWS.md` — contractor and tenant onboarding.


### PR DESCRIPTION
### Motivation

- Make Worksie's operational-readiness positioning explicit and machine-readable so product and architecture decisions align to a single canonical statement of product boundary and moat.
- Surface an MVP wedge and a strict feature rule that forces v1 work to focus on readiness outcomes (capture, validate, route, determine billing readiness, audit evidence, trigger downstream systems).
- Ensure discoverability by registering the positioning addendum in the spine and the README so agents and contributors find it easily.

### Description

- Add `docs/COMPETITIVE_POSITIONING.md` describing market gap, buyer-facing positioning, MVP wedge, product boundaries, moat strategy, and the MVP product rule.
- Update `docs/WORKSIE_SPINE.md` to register the new addendum and to define operational readiness as the canonical product boundary and responsibility.
- Update `docs/PRD.md` to add a `Product Focus` section that lists the readiness outcomes, priority verticals, and expanded out-of-scope guidance for CRM/accounting/dispatch ownership.
- Update `README.md` to include the new `docs/COMPETITIVE_POSITIONING.md` in the “Start Here” table; this is a documentation-only change with no UI edits.

### Testing

- Ran `npm run lint` and the monorepo lint pass completed successfully (`Tasks:    10 successful, 10 total`).
- Ran `npm run build` and the monorepo build completed successfully (`Tasks:    7 successful, 7 total`).
- Test checklist: [x] `npm run lint`, [x] `npm run build`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1896b07618832292854caddddfb950)