### PR TITLE
chore(ci): bump actions/checkout + setup-node to @v6 (Node-24 runtime)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -25,7 +25,7 @@ jobs:
           version: 9.12.0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: pnpm


### PR DESCRIPTION
## What

`ci.yml`: `actions/checkout@v4 → @v6`, `actions/setup-node@v4 → @v6`.

## Why

AJ Digital Repository Runtime & Dashboard Truth-State Standard (canonical v1.1, `D-2026-06-07-01`) §5 — clears GitHub's Node-20 runtime deprecation warning.

## Scope guard (§6)

- Only the two **governed** action majors changed.
- `pnpm/action-setup@v4` (ungoverned) left as-is.
- `node-version-file: .nvmrc` **untouched** — action runtime ≠ project runtime.

## Checklist

- [x] Only governed action majors changed; project runtime untouched
- [ ] CI green on this PR
- [ ] No Node-20 runtime deprecation warning in the Actions log

Draft per draft-by-default doctrine. **Do not merge without operator approval.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)