### PR TITLE
ci: bump GitHub Actions to Node 24 runtime majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -25,7 +25,7 @@ jobs:
           version: 9.12.0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: pnpm


### PR DESCRIPTION
## Changes

Bumps first-party GitHub Actions to their Node 24 runtime majors to clear the Node 20 deprecation warning.

### `.github/workflows/ci.yml`

- `actions/checkout@v4` → `actions/checkout@v6`
- `actions/setup-node@v4` → `actions/setup-node@v6`

## Notes

- `node-version:` / `node-version-file: .nvmrc` is **untouched** — this only changes the runner used by the action itself, not the Node version your project builds with.
- Only first-party GitHub-maintained actions were changed. `pnpm/action-setup` and all other third-party actions were left as-is.
- No `actions/upload-pages-artifact` or `actions/deploy-pages` were present in any workflow.

🤖 Generated with Claude Code