### PR TITLE
docs: add DOX AGENTS hierarchy

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+## Purpose
+
+Own repository automation contracts for GitHub workflows.
+
+## Ownership
+
+- `.github/workflows/` owns CI definitions and repository automation.
+- Root `AGENTS.md` owns branch, PR, remote iPhone, verification, and safety
+  rules that CI changes must respect.
+
+## Local Contracts
+
+- Keep workflow changes aligned with root validation commands:
+  `pnpm lint` and `pnpm build`.
+- Do not weaken CI coverage without an explicit task spec and approval.
+- Do not add secret values to workflow files.
+
+## Work Guidance
+
+## Verification
+
+- Run `pnpm lint` and `pnpm build` from the repository root when workflow
+  changes can affect validation behavior.
+
+## Child DOX Index
+
+- No child `AGENTS.md` files are currently required under `.github/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,109 @@
 Operating instructions for AI coding agents working on this repository. These
 apply to Codex, Claude Code, and any other agent that picks up this file.
 
+## DOX framework
+
+DOX is the AGENTS.md hierarchy installed for this repository. Agents must
+follow the nearest applicable `AGENTS.md` plus every parent `AGENTS.md` above
+it for all edits.
+
+### Core contract
+
+- `AGENTS.md` files are binding work contracts for their subtrees.
+- Work products, source materials, instructions, records, assets, and durable
+  docs must stay understandable from the nearest applicable `AGENTS.md` plus
+  every parent `AGENTS.md` above it.
+- Do not rely on memory for DOX. Re-read the applicable DOX chain in the
+  current session before editing.
+- If docs conflict, the closer doc controls local work details, but no child
+  doc may weaken DOX or this root contract.
+
+### Read before editing
+
+1. Read this root `AGENTS.md`.
+2. Identify every file or folder you expect to touch.
+3. Walk from the repository root to each target path.
+4. Read every `AGENTS.md` found along each route.
+5. If a parent `AGENTS.md` lists a child `AGENTS.md` whose scope contains the
+   path, read that child and continue from there.
+6. Use the nearest `AGENTS.md` as the local contract and parent docs for
+   repo-wide rules.
+
+### Update after editing
+
+Every meaningful change requires a DOX pass before the task is done.
+
+Update the closest owning `AGENTS.md` when a change affects:
+
+- purpose, scope, ownership, or responsibilities
+- durable structure, contracts, workflows, or operating rules
+- required inputs, outputs, permissions, constraints, side effects, or artifacts
+- user preferences about behavior, communication, process, organization, or
+  quality
+- `AGENTS.md` creation, deletion, move, rename, or index contents
+
+Update parent docs when parent-level structure, ownership, workflow, or child
+index changes. Update child docs when parent changes alter local rules. Remove
+stale or contradictory text immediately. Small edits that do not change
+behavior or contracts may leave docs unchanged, but the DOX pass still must
+happen.
+
+### Hierarchy
+
+- Root `AGENTS.md` is the DOX rail: project-wide instructions, global
+  preferences, durable workflow rules, and the top-level Child DOX Index.
+- Child `AGENTS.md` files own domain-specific instructions and their own Child
+  DOX Index.
+- Each parent explains what its direct children cover and what stays owned by
+  the parent.
+- The closer a doc is to the work, the more specific and practical it must be.
+
+### Child doc shape
+
+Create a child `AGENTS.md` when a folder becomes a durable boundary with its
+own purpose, rules, responsibilities, workflow, materials, or quality
+standards.
+
+Use this default section order:
+
+1. Purpose
+2. Ownership
+3. Local Contracts
+4. Work Guidance
+5. Verification
+6. Child DOX Index
+
+Work Guidance must reflect current standards or user instructions. If there
+are no specific standards yet, leave it empty. Verification must reflect an
+existing check. If no verification framework exists yet, leave it empty and
+update it when one exists.
+
+### Style
+
+- Keep docs concise, current, and operational.
+- Document stable contracts, not diary entries.
+- Put broad rules in parent docs and concrete details in child docs.
+- Prefer direct bullets with explicit names.
+- Do not duplicate rules across many files unless each scope needs a local
+  version.
+- Delete stale notes instead of explaining history.
+- Trim obvious statements, repeated rules, misplaced detail, and warnings for
+  risks that no longer exist.
+
+### Closeout
+
+1. Re-check changed paths against the DOX chain.
+2. Update nearest owning docs and any affected parents or children.
+3. Refresh every affected Child DOX Index.
+4. Remove stale or contradictory text.
+5. Run existing verification when relevant.
+6. Report any docs intentionally left unchanged and why.
+
+### User preferences
+
+- When the user requests a durable behavior change, record it in this root
+  contract or in the relevant child `AGENTS.md`.
+
 ## Remote iPhone workflow
 
 The repo owner often reviews work from an iPhone via GitHub mobile. They
@@ -78,3 +181,28 @@ and follow rule 2 above.
 - Never run `git push --force`, `git reset --hard`, or other destructive ops
   without explicit confirmation.
 - Never skip hooks (`--no-verify`) unless the user explicitly asks.
+
+## Child DOX Index
+
+- `.github/AGENTS.md` - CI workflow and repository automation contracts.
+- `apps/AGENTS.md` - application workspace contracts.
+  - `apps/web/AGENTS.md` - Next.js admin app.
+  - `apps/mobile/AGENTS.md` - Expo field app.
+- `dataset/AGENTS.md` - training and evaluation schema materials.
+- `docs/AGENTS.md` - canonical product, architecture, GTM, and review docs.
+- `packages/AGENTS.md` - shared workspace package contracts.
+  - `packages/db/AGENTS.md` - Drizzle schema, database client, and migration
+    ownership details.
+- `prompts/AGENTS.md` - reusable agent prompt templates.
+- `scripts/AGENTS.md` - repository scripts.
+  - `scripts/verify-rls/AGENTS.md` - RLS verification harness.
+- `supabase/AGENTS.md` - Supabase config, migrations, metadata, and seed SQL.
+
+Root continues to own workspace-level files including `package.json`,
+`pnpm-workspace.yaml`, `pnpm-lock.yaml`, `turbo.json`, `tsconfig.base.json`,
+`.editorconfig`, `.npmrc`, `.nvmrc`, `.gitignore`, `CLAUDE.md`, `README.md`,
+and this `AGENTS.md`.
+
+## Tool Prerequisites
+
+- graphifyy v0.8.36+ must be installed before working on any repo: `uv tool install graphifyy` (preferred) or `pip install graphifyy`. Run `uv tool list | grep graphify` to verify. Used for /graphify codebase analysis and knowledge graph generation.

--- a/apps/AGENTS.md
+++ b/apps/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS.md
+
+## Purpose
+
+Own application workspace rules for Worksie user-facing apps.
+
+## Ownership
+
+- `apps/web/` owns the Next.js web admin app.
+- `apps/mobile/` owns the Expo mobile field app.
+- Root owns product phase discipline, remote iPhone workflow, branch/PR rules,
+  and repository-wide validation.
+
+## Local Contracts
+
+- App changes must preserve the canonical stack in `README.md`.
+- Do not implement domain features before the Phase 3 auth, RLS, and tenancy
+  boundary is in place.
+- UI changes must follow the root remote iPhone workflow: desktop and iPhone
+  screenshots committed under `docs/screenshots/<pr-or-branch>/` and linked
+  in the PR.
+
+## Work Guidance
+
+## Verification
+
+- Run `pnpm lint` and `pnpm build` from the repository root before declaring
+  app work done.
+- For UI changes, run a Playwright screenshot pass at desktop `1440x1200` and
+  iPhone `390x844` viewports.
+
+## Child DOX Index
+
+- `web/AGENTS.md` - Next.js admin app.
+- `mobile/AGENTS.md` - Expo field app.

--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md
+
+## Purpose
+
+Own the Worksie mobile field app.
+
+## Ownership
+
+- `app/` owns Expo Router screens and layout.
+- `app.json`, `babel.config.js`, and Expo package settings own mobile runtime
+  configuration.
+
+## Local Contracts
+
+- Use Expo, Expo Router, React Native, and TypeScript.
+- Keep the mobile app aligned with the field-worker execution model in
+  `docs/PRD.md` and `docs/WORK_ORDER_LIFECYCLE.md`.
+- Do not implement offline/domain feature slices before the relevant phase
+  gate is satisfied.
+
+## Work Guidance
+
+## Verification
+
+- Run `pnpm --filter @worksie/mobile lint` when touching mobile app code.
+- Run `pnpm --filter @worksie/mobile build` when touching screens, config, or
+  mobile TypeScript.
+- Root closeout still requires `pnpm lint` and `pnpm build`.
+
+## Child DOX Index
+
+- No child `AGENTS.md` files are currently required under `apps/mobile/`.

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md
+
+## Purpose
+
+Own the Worksie web admin app.
+
+## Ownership
+
+- `src/app/` owns App Router routes, layouts, global CSS, and route handlers.
+- `src/lib/supabase/` owns web Supabase clients.
+- `src/lib/tenant/` owns tenant context helpers.
+- `src/middleware.ts` owns request middleware.
+
+## Local Contracts
+
+- Use Next.js App Router with TypeScript and Tailwind.
+- Keep Supabase SSR/browser client behavior tenant-safe.
+- Preserve `GET /healthz` behavior unless the task explicitly changes the
+  health contract.
+- Do not introduce Firebase or Firebase-compatible dependencies.
+
+## Work Guidance
+
+## Verification
+
+- Run `pnpm --filter @worksie/web lint` when touching web app code.
+- Run `pnpm --filter @worksie/web build` when touching routes, middleware,
+  configs, Supabase helpers, or UI.
+- Root closeout still requires `pnpm lint` and `pnpm build`.
+
+## Child DOX Index
+
+- No child `AGENTS.md` files are currently required under `apps/web/`.

--- a/dataset/AGENTS.md
+++ b/dataset/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS.md
+
+## Purpose
+
+Own training and evaluation schema materials.
+
+## Ownership
+
+- `worksie_training_schema.jsonl` owns the checked-in dataset schema material.
+- Root owns safety, repo workflow, and DOX rules.
+
+## Local Contracts
+
+- Do not include secrets, real client data, credentials, or private personal
+  data.
+- Keep JSONL records valid and intentionally structured.
+- Document durable schema meaning in this folder or in canonical docs when the
+  dataset contract changes.
+
+## Work Guidance
+
+## Verification
+
+- Validate JSONL syntax when editing dataset files.
+
+## Child DOX Index
+
+- No child `AGENTS.md` files are currently required under `dataset/`.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md
+
+## Purpose
+
+Own canonical product, architecture, GTM, phase, and review documentation.
+
+## Ownership
+
+- `WORKSIE_SPINE.md` is the doctrine and canonical stack contract.
+- `PRD.md`, `DOMAIN_MODEL.md`, and lifecycle docs own product and domain
+  requirements.
+- `reviews/` owns PR and readiness review checklists.
+- Root owns repo-wide AGENTS/DOX behavior.
+
+## Local Contracts
+
+- If a product, scope, or stack decision changes and `WORKSIE_SPINE.md` does
+  not reflect it, the change is not done.
+- Keep docs Markdown-first and Git Spec ready.
+- Do not silently change public positioning, phase gates, or stack decisions.
+- Delete stale contradictions instead of adding historical explanations.
+
+## Work Guidance
+
+## Verification
+
+- No automated doc-only verification is currently defined for this folder.
+- Root closeout still requires `pnpm lint` and `pnpm build`.
+
+## Child DOX Index
+
+- `reviews/` is currently governed by this `docs/AGENTS.md`.

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md
+
+## Purpose
+
+Own shared workspace package contracts for Worksie.
+
+## Ownership
+
+- `auth/` owns shared auth and tenant helpers.
+- `config/` owns shared lint and TypeScript presets.
+- `db/` owns Drizzle schema and database client.
+- `domain/` owns shared domain constants and state names.
+- `types/` owns shared utility types.
+- `ui/` owns shared design tokens and future primitives.
+
+## Local Contracts
+
+- Keep package APIs stable and intentional; shared package changes can affect
+  both web and mobile.
+- Preserve TypeScript strictness and workspace package imports.
+- Do not move database schema ownership out of `packages/db`.
+
+## Work Guidance
+
+## Verification
+
+- Run the touched package's lint/build/typecheck script when available.
+- Root closeout still requires `pnpm lint` and `pnpm build`.
+
+## Child DOX Index
+
+- `db/AGENTS.md` - Drizzle schema, database client, and migration ownership.
+- `auth/`, `config/`, `domain/`, `types/`, and `ui/` are currently governed
+  by this `packages/AGENTS.md`.

--- a/packages/db/AGENTS.md
+++ b/packages/db/AGENTS.md
@@ -1,0 +1,38 @@
+# AGENTS.md
+
+## Purpose
+
+Own the Worksie database schema source, Drizzle client surface, and migration
+coordination contract.
+
+## Ownership
+
+- `src/schema/` is the Drizzle schema source of truth.
+- `src/client.ts` owns the database client.
+- `drizzle.config.ts` owns Drizzle generation configuration.
+- `../../supabase/migrations/` owns checked-in SQL migrations applied by the
+  Supabase CLI.
+
+## Local Contracts
+
+- Follow `packages/db/README.md` for migration ownership.
+- Use `drizzle-kit generate` only when intentionally generating a new
+  Drizzle-authored schema migration.
+- Hand-written RLS, policy, audit, and append-only behavior belongs in
+  Supabase SQL migrations and must not be skipped because Drizzle metadata
+  exists.
+- Do not weaken tenant boundaries, RLS assumptions, audit behavior, or schema
+  hard rules without an explicit task spec.
+
+## Work Guidance
+
+## Verification
+
+- Run `pnpm --filter @worksie/db build` for database package changes.
+- Run `supabase db reset` when migration behavior must be validated and local
+  Supabase is available.
+- Root closeout still requires `pnpm lint` and `pnpm build`.
+
+## Child DOX Index
+
+- No child `AGENTS.md` files are currently required under `packages/db/`.

--- a/prompts/AGENTS.md
+++ b/prompts/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS.md
+
+## Purpose
+
+Own reusable agent prompt templates.
+
+## Ownership
+
+- Prompt files define repeatable instructions for specialized agent workflows.
+- Root owns global safety, repo workflow, and DOX rules that prompts must not
+  weaken.
+
+## Local Contracts
+
+- Keep prompts operational, copy/paste-ready, and scoped to the intended tool.
+- Do not include secrets, private credentials, or client-sensitive data.
+- Do not create prompts that authorize destructive work without the root
+  approval gate.
+
+## Work Guidance
+
+## Verification
+
+- No automated prompt verification is currently defined for this folder.
+
+## Child DOX Index
+
+- No child `AGENTS.md` files are currently required under `prompts/`.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS.md
+
+## Purpose
+
+Own repository utility scripts and script-specific verification workflows.
+
+## Ownership
+
+- `verify-rls/` owns the RLS verification harness.
+- Root owns repository-wide validation and safety rules.
+
+## Local Contracts
+
+- Scripts must avoid secret leakage in logs and generated output.
+- Prefer deterministic, repeatable checks over one-off shell behavior.
+- Do not add destructive scripts without explicit approval and documented
+  rollback behavior.
+
+## Work Guidance
+
+## Verification
+
+- Run the touched script package's verification command when available.
+- Root closeout still requires `pnpm lint` and `pnpm build`.
+
+## Child DOX Index
+
+- `verify-rls/AGENTS.md` - RLS verification harness.

--- a/scripts/verify-rls/AGENTS.md
+++ b/scripts/verify-rls/AGENTS.md
@@ -1,0 +1,30 @@
+# AGENTS.md
+
+## Purpose
+
+Own the local RLS verification harness.
+
+## Ownership
+
+- `src/index.ts` owns the TypeScript verification runner.
+- `sql/` owns SQL support fixtures for verification.
+- `package.json` owns script entry points for this harness.
+
+## Local Contracts
+
+- Keep verification fixtures explicit and auditable.
+- Do not log secrets or service-role values.
+- Keep auth stubs limited to local verification behavior.
+
+## Work Guidance
+
+## Verification
+
+- Run `pnpm --filter @worksie/verify-rls build` when changing the harness.
+- Run the package verification script when local Supabase/database prerequisites
+  are available.
+- Root closeout still requires `pnpm lint` and `pnpm build`.
+
+## Child DOX Index
+
+- No child `AGENTS.md` files are currently required under `scripts/verify-rls/`.

--- a/supabase/AGENTS.md
+++ b/supabase/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS.md
+
+## Purpose
+
+Own Supabase local configuration, migrations, metadata, and seed SQL.
+
+## Ownership
+
+- `config.toml` owns local Supabase CLI configuration.
+- `migrations/` owns checked-in SQL migrations and Drizzle metadata.
+- `seed/` owns seed fixtures.
+- `../packages/db/` owns Drizzle schema source and database client code.
+
+## Local Contracts
+
+- Treat migrations as durable database history; do not rewrite applied
+  migration intent casually.
+- Preserve RLS, policy, audit, and append-only behavior.
+- Do not commit real secrets, service-role keys, client data, or credentialed
+  fixtures.
+- Coordinate schema changes with `packages/db/AGENTS.md`.
+
+## Work Guidance
+
+## Verification
+
+- Run `supabase db reset` when migration or seed behavior must be validated
+  and local Supabase is available.
+- Run `pnpm --filter @worksie/db build` when migration changes correspond to
+  Drizzle schema changes.
+- Root closeout still requires `pnpm lint` and `pnpm build`.
+
+## Child DOX Index
+
+- `migrations/` and `seed/` are currently governed by this `supabase/AGENTS.md`.


### PR DESCRIPTION
## Summary

Adds the DOX AGENTS.md hierarchy for Worksie so agents can identify repo-wide and subtree-specific operating contracts before edits.

## Local Context

Local branch: `codex/dox-agents-hierarchy`
Local worktree: `C:\dev\worksie`
Workflow: local Codex Desktop plus terminal validation.

## Scope

Documentation:
- Root `AGENTS.md` DOX framework contract and Child DOX Index.
- Child `AGENTS.md` files for `.github`, `apps`, `apps/web`, `apps/mobile`, `dataset`, `docs`, `packages`, `packages/db`, `prompts`, `scripts`, `scripts/verify-rls`, and `supabase`.

Runtime code:
- None.

Tests:
- None added.

Hooks:
- None.

CI:
- None.

Config:
- None.

Agent instructions:
- Adds advisory AGENTS.md hierarchy and local work contracts.

MCP/Obsidian access:
- None.

Governance files:
- Adds DOX governance docs.

Generated artifacts:
- None committed.

## Why This Matters

This makes agent work boundaries explicit before GTM/MVP roadmap work resumes, reducing accidental edits across app, package, database, docs, script, and Supabase ownership boundaries.

## Validation

Local validation passed:
- `git diff --check`
- `rg -n "(SECRET|TOKEN|PASSWORD|PRIVATE KEY|BEGIN|sk-|ghp_|service_role|SUPABASE_SERVICE_ROLE_KEY)" AGENTS.md .github/AGENTS.md apps/AGENTS.md apps/mobile/AGENTS.md apps/web/AGENTS.md dataset/AGENTS.md docs/AGENTS.md packages/AGENTS.md packages/db/AGENTS.md prompts/AGENTS.md scripts/AGENTS.md scripts/verify-rls/AGENTS.md supabase/AGENTS.md`
- `npm exec --yes --package=node@20 --package=pnpm@9.12.0 -- pnpm lint`
- `npm exec --yes --package=node@20 --package=pnpm@9.12.0 -- pnpm build`
- `npm exec --yes --package=node@20 --package=pnpm@9.12.0 -- pnpm typecheck`
- `npm exec --yes --package=node@20 --package=pnpm@9.12.0 -- pnpm test`

## Risk Review

Risk: Medium because this changes agent behavior and repo governance documentation.

Affects:
- Runtime behavior: no
- CI/CD: no
- Git hooks: no
- Agent behavior: yes, advisory
- MCP access: no
- Obsidian/vault access: no
- Secrets or credentials: no
- Local machine paths: mentions only repo/tool commands already present in instructions
- Repo governance: yes
- Documentation architecture: yes
- Worktree behavior: no
- Remote deployment behavior: no

Risk boundary: advisory governance only, not enforcement-level automation.

## Governance / Protocol Alignment

Aligns with:
- DOX repo context standard
- Repo operating system standard
- Worktree protocol by clarifying local ownership boundaries

## Human Review Required

Human review is required before merge because this changes agent instructions and repo governance docs.

## Known Limitations / Follow-Up

- This does not add enforcement hooks for DOX; it is advisory documentation.
- Future subtree docs should be added only when a folder becomes a durable ownership boundary.
