### PR TITLE
feat: add Phase 4A ramp read model

### DIFF
--- a/docs/PHASE_4_ACCESSIBILITY_RAMP_TASK_SPEC.md
+++ b/docs/PHASE_4_ACCESSIBILITY_RAMP_TASK_SPEC.md
@@ -1,7 +1,7 @@
 ---
 title: Phase 4 - Accessibility Ramp First Slice Task Spec
-status: draft
-version: v0.1
+status: active
+version: v0.2
 owner: AJ Digital LLC / Audio Jones
 related_spine: docs/WORKSIE_SPINE.md
 related_prd: docs/PRD.md
@@ -143,7 +143,7 @@ as an accessibility ramp install while keeping the read model generic:
 
 ### Improve Handoff
 
-Implementation may start only after Audio explicitly approves this task spec.
+Implementation started after Audio approved this task spec with `Proceed`.
 
 Recommended first PR sequence:
 
@@ -270,9 +270,31 @@ inspection shows a smaller safe first step.
 
 ## 6. Open Questions
 
-- Should Phase 4A use typed in-repo fixtures only, or also add a Supabase seed
-  file for the ramp install scenario?
+- Phase 4A uses typed in-repo fixtures only. Supabase seed data is deferred
+  until a database-backed slice is explicitly approved.
 - Should the first web surface be `/work-orders` list plus detail, or a single
   `/work-orders/ramp-install-demo` detail route?
-- Should the first mobile surface be fixture-only or share a package-level
-  read-model adapter with the web app from the first PR?
+- The first mobile surface should share the package-level read-model adapter
+  with the web app when Phase 4C starts.
+
+## 7. Phase 4A Implementation Notes
+
+Phase 4A is scoped to `@worksie/domain`:
+
+- `packages/domain/src/accessibility-ramp-read-model.ts` owns the typed ramp
+  install fixture and read-model projector.
+- `packages/domain/test/accessibility-ramp-read-model.test.ts` verifies the
+  fixture projects tenant id, service name, work-order status, checklist
+  requirements, proof requirements, sign-off requirement, line items, payout
+  readiness marker, and tenant mismatch guard.
+- `packages/domain/package.json` runs the Phase 4A test with `tsx` and includes
+  `test/` in lint coverage.
+
+No UI, route, database migration, RLS change, file upload, sign-off capture,
+payout automation, production deployment, or client data is part of Phase 4A.
+
+## 8. Change Log
+
+- v0.1 | 2026-06-27 | Drafted Phase 4 accessibility ramp task spec.
+- v0.2 | 2026-06-27 | Marked task spec active after approval and recorded
+  Phase 4A typed-fixture implementation boundary.

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -9,15 +9,16 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "lint": "eslint src --max-warnings 0",
+    "lint": "eslint src test --max-warnings 0",
     "typecheck": "tsc --noEmit",
     "build": "tsc --noEmit",
-    "test": "echo 'Phase 1: no tests yet'",
+    "test": "tsc --noEmit -p tsconfig.test.json && tsx test/accessibility-ramp-read-model.test.ts",
     "clean": "rm -rf dist .turbo node_modules"
   },
   "devDependencies": {
     "@worksie/config": "workspace:*",
     "eslint": "^8.57.1",
+    "tsx": "^4.19.2",
     "typescript": "^5.6.3"
   }
 }

--- a/packages/domain/src/accessibility-ramp-read-model.ts
+++ b/packages/domain/src/accessibility-ramp-read-model.ts
@@ -1,0 +1,438 @@
+import type {
+  ContractorDocumentStatus,
+  MembershipRole,
+  MembershipStatus,
+  PayoutRuleMode,
+  ProofOfWorkKind,
+  WorkOrderState
+} from "./index";
+
+type IsoDateTime = string;
+
+export type RampComplianceRequirement = {
+  readonly documentType: string;
+  readonly status: ContractorDocumentStatus;
+  readonly gating: boolean;
+  readonly expiresOn?: IsoDateTime;
+};
+
+export type RampChecklistStepFixture = {
+  readonly id: string;
+  readonly label: string;
+  readonly ordinal: number;
+  readonly requiresPhoto: boolean;
+  readonly requiresSignature: boolean;
+  readonly completedAt?: IsoDateTime;
+};
+
+export type RampLineItemFixture = {
+  readonly id: string;
+  readonly description: string;
+  readonly quantity: number;
+  readonly unit: string;
+  readonly pieceRateAmount: number;
+  readonly completedAt?: IsoDateTime;
+};
+
+export type RampInstallFixture = {
+  readonly tenant: {
+    readonly id: string;
+    readonly name: string;
+    readonly timezone: string;
+  };
+  readonly businessProfile: {
+    readonly id: string;
+    readonly tenantId: string;
+    readonly legalName: string;
+    readonly dba: string;
+    readonly jurisdictions: readonly string[];
+  };
+  readonly serviceDefinition: {
+    readonly id: string;
+    readonly tenantId: string;
+    readonly name: string;
+    readonly category: "ramp_install";
+    readonly requiredGear: readonly string[];
+    readonly requiredDocuments: readonly string[];
+    readonly requiredSafetySteps: readonly string[];
+    readonly checklistTemplateId: string;
+    readonly customerSignoffRequired: boolean;
+    readonly defaultPayoutRuleId: string;
+  };
+  readonly payoutRule: {
+    readonly id: string;
+    readonly tenantId: string;
+    readonly name: string;
+    readonly mode: PayoutRuleMode;
+  };
+  readonly checklistTemplate: {
+    readonly id: string;
+    readonly tenantId: string;
+    readonly name: string;
+    readonly steps: readonly RampChecklistStepFixture[];
+  };
+  readonly customer: {
+    readonly id: string;
+    readonly tenantId: string;
+    readonly name: string;
+    readonly address: string;
+  };
+  readonly contractorMembership: {
+    readonly id: string;
+    readonly tenantId: string;
+    readonly displayName: string;
+    readonly role: Extract<MembershipRole, "contractor">;
+    readonly status: MembershipStatus;
+  };
+  readonly complianceRequirements: readonly RampComplianceRequirement[];
+  readonly safetyAcknowledgements: readonly string[];
+  readonly workOrder: {
+    readonly id: string;
+    readonly tenantId: string;
+    readonly serviceDefinitionId: string;
+    readonly customerId: string;
+    readonly assignedContractorMembershipId: string;
+    readonly status: WorkOrderState;
+    readonly scheduledFor: IsoDateTime;
+    readonly address: string;
+    readonly serviceSnapshot: {
+      readonly serviceName: string;
+      readonly requiredGear: readonly string[];
+      readonly requiredDocuments: readonly string[];
+      readonly requiredSafetySteps: readonly string[];
+      readonly customerSignoffRequired: boolean;
+      readonly payoutRuleName: string;
+    };
+  };
+  readonly lineItems: readonly RampLineItemFixture[];
+};
+
+export type RampProofRequirement = {
+  readonly checklistStepId: string;
+  readonly checklistLabel: string;
+  readonly kinds: readonly ProofOfWorkKind[];
+  readonly satisfied: boolean;
+};
+
+export type AccessibilityRampWorkOrderReadModel = {
+  readonly tenantId: string;
+  readonly business: {
+    readonly name: string;
+    readonly jurisdictions: readonly string[];
+  };
+  readonly serviceDefinition: {
+    readonly id: string;
+    readonly name: string;
+    readonly category: "ramp_install";
+    readonly requiredGear: readonly string[];
+    readonly requiredDocuments: readonly string[];
+    readonly requiredSafetySteps: readonly string[];
+  };
+  readonly workOrder: {
+    readonly id: string;
+    readonly status: WorkOrderState;
+    readonly scheduledFor: IsoDateTime;
+    readonly address: string;
+  };
+  readonly customer: {
+    readonly id: string;
+    readonly name: string;
+    readonly address: string;
+  };
+  readonly assignedContractor: {
+    readonly id: string;
+    readonly displayName: string;
+    readonly dispatchable: boolean;
+  };
+  readonly compliance: {
+    readonly dispatchGate: "green" | "blocked";
+    readonly requirements: readonly RampComplianceRequirement[];
+    readonly safetyAcknowledgements: readonly string[];
+  };
+  readonly checklist: readonly RampChecklistStepFixture[];
+  readonly proofRequirements: readonly RampProofRequirement[];
+  readonly signoff: {
+    readonly required: boolean;
+    readonly captured: boolean;
+  };
+  readonly lineItems: readonly RampLineItemFixture[];
+  readonly payoutReadiness: {
+    readonly marker: "not_ready" | "evidence_ready";
+    readonly automation: "not_started";
+    readonly canGeneratePayoutLines: false;
+  };
+};
+
+const tenantId = "tenant_accessibility_ramp_demo";
+
+export const accessibilityRampInstallFixture = {
+  tenant: {
+    id: tenantId,
+    name: "Worksie Ramp Demo Tenant",
+    timezone: "America/New_York"
+  },
+  businessProfile: {
+    id: "business_profile_ramp_demo",
+    tenantId,
+    legalName: "Worksie Ramp Demo LLC",
+    dba: "Worksie Ramp Demo",
+    jurisdictions: ["Florida", "Pinellas County"]
+  },
+  serviceDefinition: {
+    id: "service_accessibility_ramp_install",
+    tenantId,
+    name: "Accessibility Ramp Install",
+    category: "ramp_install",
+    requiredGear: [
+      "ramp sections",
+      "handrails",
+      "anchors",
+      "hammer drill",
+      "levels",
+      "PPE"
+    ],
+    requiredDocuments: ["w9", "coi", "state_or_county_license"],
+    requiredSafetySteps: [
+      "heavy_lifting",
+      "electrical_exposure_check",
+      "heat_hydration"
+    ],
+    checklistTemplateId: "checklist_template_ramp_install",
+    customerSignoffRequired: true,
+    defaultPayoutRuleId: "payout_rule_ramp_piece_rate"
+  },
+  payoutRule: {
+    id: "payout_rule_ramp_piece_rate",
+    tenantId,
+    name: "Ramp install piece-rate",
+    mode: "piece_rate"
+  },
+  checklistTemplate: {
+    id: "checklist_template_ramp_install",
+    tenantId,
+    name: "Accessibility ramp install checklist",
+    steps: [
+      {
+        id: "step_verify_site",
+        label: "Verify site access and measurements",
+        ordinal: 1,
+        requiresPhoto: true,
+        requiresSignature: false
+      },
+      {
+        id: "step_stage_sections",
+        label: "Stage ramp sections and safety equipment",
+        ordinal: 2,
+        requiresPhoto: true,
+        requiresSignature: false
+      },
+      {
+        id: "step_anchor_ramp",
+        label: "Install and anchor ramp",
+        ordinal: 3,
+        requiresPhoto: true,
+        requiresSignature: false
+      },
+      {
+        id: "step_install_handrails",
+        label: "Install handrails",
+        ordinal: 4,
+        requiresPhoto: true,
+        requiresSignature: false
+      },
+      {
+        id: "step_capture_final_photos",
+        label: "Capture final photos",
+        ordinal: 5,
+        requiresPhoto: true,
+        requiresSignature: false
+      },
+      {
+        id: "step_customer_signoff",
+        label: "Collect customer sign-off",
+        ordinal: 6,
+        requiresPhoto: false,
+        requiresSignature: true
+      }
+    ]
+  },
+  customer: {
+    id: "customer_ramp_demo",
+    tenantId,
+    name: "Jordan Smith",
+    address: "100 Example Way, Clearwater, FL"
+  },
+  contractorMembership: {
+    id: "membership_contractor_ramp_demo",
+    tenantId,
+    displayName: "Taylor Installer",
+    role: "contractor",
+    status: "active"
+  },
+  complianceRequirements: [
+    {
+      documentType: "w9",
+      status: "verified",
+      gating: true
+    },
+    {
+      documentType: "coi",
+      status: "verified",
+      gating: true,
+      expiresOn: "2026-12-31T23:59:59.000Z"
+    },
+    {
+      documentType: "state_or_county_license",
+      status: "verified",
+      gating: true,
+      expiresOn: "2026-12-31T23:59:59.000Z"
+    }
+  ],
+  safetyAcknowledgements: [
+    "heavy_lifting",
+    "electrical_exposure_check",
+    "heat_hydration"
+  ],
+  workOrder: {
+    id: "work_order_ramp_demo",
+    tenantId,
+    serviceDefinitionId: "service_accessibility_ramp_install",
+    customerId: "customer_ramp_demo",
+    assignedContractorMembershipId: "membership_contractor_ramp_demo",
+    status: "in_progress",
+    scheduledFor: "2026-07-06T13:00:00.000Z",
+    address: "100 Example Way, Clearwater, FL",
+    serviceSnapshot: {
+      serviceName: "Accessibility Ramp Install",
+      requiredGear: [
+        "ramp sections",
+        "handrails",
+        "anchors",
+        "hammer drill",
+        "levels",
+        "PPE"
+      ],
+      requiredDocuments: ["w9", "coi", "state_or_county_license"],
+      requiredSafetySteps: [
+        "heavy_lifting",
+        "electrical_exposure_check",
+        "heat_hydration"
+      ],
+      customerSignoffRequired: true,
+      payoutRuleName: "Ramp install piece-rate"
+    }
+  },
+  lineItems: [
+    {
+      id: "line_item_ramp_sections",
+      description: "Ramp sections installed",
+      quantity: 3,
+      unit: "each",
+      pieceRateAmount: 125
+    },
+    {
+      id: "line_item_handrails",
+      description: "Handrails installed",
+      quantity: 2,
+      unit: "each",
+      pieceRateAmount: 75
+    }
+  ]
+} as const satisfies RampInstallFixture;
+
+export function createAccessibilityRampInstallReadModel(
+  fixture: RampInstallFixture = accessibilityRampInstallFixture
+): AccessibilityRampWorkOrderReadModel {
+  assertSingleTenantFixture(fixture);
+
+  const proofRequirements = fixture.checklistTemplate.steps
+    .filter((step) => step.requiresPhoto || step.requiresSignature)
+    .map((step) => ({
+      checklistStepId: step.id,
+      checklistLabel: step.label,
+      kinds: [
+        ...(step.requiresPhoto ? ["photo" as const] : []),
+        ...(step.requiresSignature ? ["signature" as const] : [])
+      ],
+      satisfied: false
+    }));
+
+  const dispatchable =
+    fixture.contractorMembership.status === "active" &&
+    fixture.complianceRequirements.every(
+      (requirement) => !requirement.gating || requirement.status === "verified"
+    ) &&
+    fixture.serviceDefinition.requiredSafetySteps.every((step) =>
+      fixture.safetyAcknowledgements.includes(step)
+    );
+
+  return {
+    tenantId: fixture.tenant.id,
+    business: {
+      name: fixture.businessProfile.dba || fixture.businessProfile.legalName,
+      jurisdictions: fixture.businessProfile.jurisdictions
+    },
+    serviceDefinition: {
+      id: fixture.serviceDefinition.id,
+      name: fixture.serviceDefinition.name,
+      category: fixture.serviceDefinition.category,
+      requiredGear: fixture.serviceDefinition.requiredGear,
+      requiredDocuments: fixture.serviceDefinition.requiredDocuments,
+      requiredSafetySteps: fixture.serviceDefinition.requiredSafetySteps
+    },
+    workOrder: {
+      id: fixture.workOrder.id,
+      status: fixture.workOrder.status,
+      scheduledFor: fixture.workOrder.scheduledFor,
+      address: fixture.workOrder.address
+    },
+    customer: {
+      id: fixture.customer.id,
+      name: fixture.customer.name,
+      address: fixture.customer.address
+    },
+    assignedContractor: {
+      id: fixture.contractorMembership.id,
+      displayName: fixture.contractorMembership.displayName,
+      dispatchable
+    },
+    compliance: {
+      dispatchGate: dispatchable ? "green" : "blocked",
+      requirements: fixture.complianceRequirements,
+      safetyAcknowledgements: fixture.safetyAcknowledgements
+    },
+    checklist: fixture.checklistTemplate.steps,
+    proofRequirements,
+    signoff: {
+      required: fixture.serviceDefinition.customerSignoffRequired,
+      captured: false
+    },
+    lineItems: fixture.lineItems,
+    payoutReadiness: {
+      marker: "not_ready",
+      automation: "not_started",
+      canGeneratePayoutLines: false
+    }
+  };
+}
+
+function assertSingleTenantFixture(fixture: RampInstallFixture): void {
+  const expectedTenantId = fixture.tenant.id;
+  const scopedRows = [
+    ["businessProfile", fixture.businessProfile.tenantId],
+    ["serviceDefinition", fixture.serviceDefinition.tenantId],
+    ["payoutRule", fixture.payoutRule.tenantId],
+    ["checklistTemplate", fixture.checklistTemplate.tenantId],
+    ["customer", fixture.customer.tenantId],
+    ["contractorMembership", fixture.contractorMembership.tenantId],
+    ["workOrder", fixture.workOrder.tenantId]
+  ] as const;
+
+  for (const [name, rowTenantId] of scopedRows) {
+    if (rowTenantId !== expectedTenantId) {
+      throw new Error(
+        `Ramp install fixture tenant mismatch: ${name} has ${rowTenantId}, expected ${expectedTenantId}`
+      );
+    }
+  }
+}

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -69,3 +69,16 @@ export type ProofOfWorkKind = (typeof PROOF_OF_WORK_KINDS)[number];
 // Sync classes per docs/OFFLINE_FIRST_ARCHITECTURE.md.
 export const SYNC_CLASSES = ["A_reference", "B_assigned", "C_append_only", "D_server_only"] as const;
 export type SyncClass = (typeof SYNC_CLASSES)[number];
+
+export {
+  accessibilityRampInstallFixture,
+  createAccessibilityRampInstallReadModel
+} from "./accessibility-ramp-read-model";
+export type {
+  AccessibilityRampWorkOrderReadModel,
+  RampChecklistStepFixture,
+  RampComplianceRequirement,
+  RampInstallFixture,
+  RampLineItemFixture,
+  RampProofRequirement
+} from "./accessibility-ramp-read-model";

--- a/packages/domain/test/accessibility-ramp-read-model.test.ts
+++ b/packages/domain/test/accessibility-ramp-read-model.test.ts
@@ -1,0 +1,107 @@
+import {
+  accessibilityRampInstallFixture,
+  createAccessibilityRampInstallReadModel,
+  type RampInstallFixture
+} from "../src/accessibility-ramp-read-model";
+
+const readModel = createAccessibilityRampInstallReadModel();
+
+assertEqual(readModel.tenantId, accessibilityRampInstallFixture.tenant.id);
+assertEqual(
+  readModel.serviceDefinition.name,
+  "Accessibility Ramp Install"
+);
+assertEqual(readModel.serviceDefinition.category, "ramp_install");
+assertEqual(readModel.workOrder.status, "in_progress");
+assertEqual(readModel.assignedContractor.dispatchable, true);
+assertEqual(readModel.compliance.dispatchGate, "green");
+assertEqual(readModel.signoff.required, true);
+assertEqual(readModel.signoff.captured, false);
+assertEqual(readModel.payoutReadiness.marker, "not_ready");
+assertEqual(readModel.payoutReadiness.automation, "not_started");
+assertEqual(readModel.payoutReadiness.canGeneratePayoutLines, false);
+
+assertDeepEqual(readModel.serviceDefinition.requiredDocuments, [
+  "w9",
+  "coi",
+  "state_or_county_license"
+]);
+assertDeepEqual(readModel.serviceDefinition.requiredSafetySteps, [
+  "heavy_lifting",
+  "electrical_exposure_check",
+  "heat_hydration"
+]);
+
+assertOk(
+  readModel.serviceDefinition.requiredGear.includes("ramp sections"),
+  "fixture includes ramp install gear"
+);
+assertOk(
+  readModel.checklist.some((step) => step.label === "Install and anchor ramp"),
+  "fixture includes ramp installation checklist step"
+);
+assertOk(
+  readModel.proofRequirements.some(
+    (requirement) =>
+      requirement.checklistStepId === "step_capture_final_photos" &&
+      requirement.kinds.includes("photo")
+  ),
+  "fixture includes photo proof requirement"
+);
+assertOk(
+  readModel.proofRequirements.some(
+    (requirement) =>
+      requirement.checklistStepId === "step_customer_signoff" &&
+      requirement.kinds.includes("signature")
+  ),
+  "fixture includes signature proof requirement"
+);
+assertEqual(readModel.lineItems.length, 2);
+
+const mismatchedFixture: RampInstallFixture = {
+  ...accessibilityRampInstallFixture,
+  workOrder: {
+    ...accessibilityRampInstallFixture.workOrder,
+    tenantId: "tenant_other"
+  }
+};
+
+assertThrows(
+  () => createAccessibilityRampInstallReadModel(mismatchedFixture),
+  /tenant mismatch/
+);
+
+function assertEqual<T>(actual: T, expected: T): void {
+  if (actual !== expected) {
+    throw new Error(`Expected ${String(expected)}, received ${String(actual)}`);
+  }
+}
+
+function assertDeepEqual(actual: unknown, expected: unknown): void {
+  const actualJson = JSON.stringify(actual);
+  const expectedJson = JSON.stringify(expected);
+
+  if (actualJson !== expectedJson) {
+    throw new Error(`Expected ${expectedJson}, received ${actualJson}`);
+  }
+}
+
+function assertOk(value: boolean, message: string): void {
+  if (!value) {
+    throw new Error(message);
+  }
+}
+
+function assertThrows(fn: () => unknown, pattern: RegExp): void {
+  try {
+    fn();
+  } catch (error) {
+    if (error instanceof Error && pattern.test(error.message)) {
+      return;
+    }
+
+    throw error;
+  }
+
+  throw new Error(`Expected function to throw ${pattern.source}`);
+}

--- a/packages/domain/tsconfig.test.json
+++ b/packages/domain/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,6 +198,9 @@ importers:
       eslint:
         specifier: ^8.57.1
         version: 8.57.1
+      tsx:
+        specifier: ^4.19.2
+        version: 4.22.1
       typescript:
         specifier: ^5.6.3
         version: 5.9.3


### PR DESCRIPTION
## Summary

Adds the Phase 4A accessibility ramp install read-model contract in `@worksie/domain`.

This PR creates a fictional ramp-install fixture, a read-model projector, exported types, a tenant consistency guard, and executable assertions for the approved accessibility ramp pilot. It does not add UI, routes, database migrations, mutations, uploads, payouts, production deployment, or client data.

## Local Context

Local branch: `codex/phase-4a-ramp-read-model`
Local worktree: `C:\dev\worksie`
Workflow: local Codex Desktop plus terminal validation.
Base branch: `codex/post-consolidation-roadmap-state` so this remains stacked on the Phase 4 task-spec/docs PR.

## Scope

Documentation:
- `docs/PHASE_4_ACCESSIBILITY_RAMP_TASK_SPEC.md` marks the spec active after approval and records the Phase 4A typed-fixture implementation boundary.

Runtime code:
- `packages/domain/src/accessibility-ramp-read-model.ts` adds the typed fixture, read-model shape, projector, and tenant mismatch guard.
- `packages/domain/src/index.ts` exports the new fixture, projector, and types.

Tests:
- `packages/domain/test/accessibility-ramp-read-model.test.ts` verifies tenant id, service name, work-order status, checklist requirements, proof requirements, sign-off requirement, line items, payout-readiness marker, and tenant mismatch behavior.
- `packages/domain/tsconfig.test.json` typechecks the new test file.

Hooks:
- None.

CI:
- None.

Config:
- `packages/domain/package.json` now runs the Phase 4A test and lints `test/`.
- `pnpm-lock.yaml` updated for a dev-only `tsx` test runner dependency in `@worksie/domain`.

Agent instructions:
- No AGENTS.md changes.

MCP/Obsidian access:
- None.

Governance files:
- Phase 4 task spec updated.

Generated artifacts:
- None committed.

## Why This Matters

Phase 4A gives web and mobile a shared, typed domain contract for the approved accessibility ramp workflow before any UI or mutation work begins. This keeps the pilot reusable and schema-aligned while avoiding a premature client-specific app, database migration, payout automation, or production claim.

## Validation

Local validation passed:
- [x] `git diff --check`
- [x] `npm exec --yes --package=node@20 --package=pnpm@9.12.0 -- pnpm --filter @worksie/domain lint`
- [x] `npm exec --yes --package=node@20 --package=pnpm@9.12.0 -- pnpm --filter @worksie/domain typecheck`
- [x] `npm exec --yes --package=node@20 --package=pnpm@9.12.0 -- pnpm --filter @worksie/domain test`
- [x] `npm exec --yes --package=node@20 --package=pnpm@9.12.0 -- pnpm lint`
- [x] `npm exec --yes --package=node@20 --package=pnpm@9.12.0 -- pnpm build`
- [x] `npm exec --yes --package=node@20 --package=pnpm@9.12.0 -- pnpm typecheck`
- [x] `npm exec --yes --package=node@20 --package=pnpm@9.12.0 -- pnpm test`

GitHub/CI validation pending:
- [ ] `ci / lint / typecheck / build` for the latest pushed commit.

UI evidence:
- Not applicable. This PR has no UI changes.

## Risk Review

Risk: Medium. This changes a shared package API and adds a dev dependency for package tests.

Affects:
- Runtime behavior: yes, shared domain exports only
- CI/CD: no workflow changes
- Git hooks: no
- Agent behavior: indirectly through Phase 4 task-spec status
- MCP access: no
- Obsidian/vault access: no
- Secrets or credentials: no
- Local machine paths: no new private path exposure beyond existing repo docs
- Repo governance: yes, Phase 4 task spec note
- Documentation architecture: no structural change
- Worktree behavior: no
- Remote deployment behavior: no
- Database/RLS: no
- Payout/payment behavior: no

## Governance / Protocol Alignment

Aligns with:
- DOX repo context standard
- DMAIC greenfield build-charter discipline
- Phase 4A implementation sequence from `docs/PHASE_4_ACCESSIBILITY_RAMP_TASK_SPEC.md`
- Repo operating system standard
- GTM safe-gate discipline

## Human Review Required

Human review is required before merge because this changes a shared package API and adds a package dev dependency. Runtime blast radius is intentionally limited to `@worksie/domain` exports and tests.

## Known Limitations / Follow-Up

- Does not add web admin UI.
- Does not add mobile UI.
- Does not add Supabase seed data.
- Does not add database migrations or RLS changes.
- Does not add work-order mutations, proof upload, sign-off capture, payout automation, or deployment.
- Next slice: Phase 4B web admin read-only route after this API is accepted.
