### PR TITLE
test+fix: Vitest baseline and preferredTenantId boundary fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,13 +124,22 @@ path. Surface visual progress in places that render on mobile.
      branch and reference them in the PR body / comment using raw GitHub URLs
      or relative markdown links (`![desktop](docs/screenshots/.../desktop.png)`).
    - Include hover, error, and empty states when relevant to the change.
-3. **Prefer the Vercel preview URL when possible.** Vercel auto-deploys a
-   preview for every PR. Grab the preview URL from the PR's checks (the
-   "Visit Preview" link on the Vercel check) and paste it into the PR
-   description with the exact route to verify
-   (e.g. `https://<branch>-worksie.vercel.app/dashboard`). Confirm the
-   Vercel check is green before declaring the task done. If the preview
-   build failed, fix it — do not ship.
+3. **Prefer a Vercel preview URL when one exists — but verify it does.**
+   As of 2026-07-31 the Vercel integration is **not** producing deployments
+   for this repository. `vercel[bot]` last deployed on 2025-10-16; pull
+   requests since then produce CI runs and no preview. Do not claim a
+   preview URL you have not seen, and do not block on a Vercel check that
+   never appears.
+
+   If previews are reconnected: grab the URL from the "Visit Preview" link
+   on the Vercel check, paste it into the PR description with the exact
+   route to verify (e.g. `https://<branch>-worksie.vercel.app/dashboard`),
+   and confirm the check is green before declaring the task done. If the
+   preview build failed, fix it — do not ship.
+
+   Until then, the CI check `lint / typecheck / build` is the only
+   automated gate, and UI evidence must come from committed screenshots
+   per rule 2.
 4. **Non-UI progress goes in the PR description, not chat-only output.**
    Update the PR body with: what changed, what was tested, trimmed
    command output (pass/fail + key lines), and links to screenshots or the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,7 +148,12 @@ Run from the repository root:
 ```bash
 pnpm lint
 pnpm build
+pnpm test
 ```
+
+`pnpm test` runs Vitest via Turbo. Packages with no tests yet declare no `test`
+script and are skipped — do not add a placeholder that always passes, because a
+green step that asserts nothing is worse than a missing one.
 
 If the local `pnpm` shim is unavailable or broken, `npm run lint` and
 `npm run build` are acceptable validation fallbacks because they delegate to

--- a/docs/PHASE_3_AUTH.md
+++ b/docs/PHASE_3_AUTH.md
@@ -60,15 +60,23 @@ returns one of:
 
 | Outcome             | When                                                     |
 |---------------------|----------------------------------------------------------|
-| `ok: true`          | Single active membership, or `preferredTenantId` matches |
+| `ok: true`          | `preferredTenantId` matches an active membership, or none was supplied and exactly one membership is active |
 | `unauthenticated`   | No Supabase session                                      |
 | `no_user_row`       | Session present but no `public.users` row yet            |
 | `no_membership`     | User exists but zero memberships                         |
 | `no_active_membership` | All memberships are `invited` or `suspended`          |
 | `multiple_memberships` | More than one `active` membership and no preference   |
+| `preferred_tenant_unavailable` | `preferredTenantId` was supplied and the user has no `active` membership in it |
 
 `multiple_memberships` is deliberately an error rather than a silent
 pick. Phase 4+ will add an explicit tenant switcher.
+
+`preferredTenantId` is a **constraint, not a hint**. When supplied it is
+validated on every path — including the single-membership one — so the
+guarantee "you get the tenant you asked for, or an error" never depends
+on how many memberships the user happens to have. The resolver never
+falls back to a different tenant. Callers that mean "any active
+membership will do" express that by omitting the field.
 
 ## Protected route
 
@@ -172,6 +180,7 @@ A successful run prints `verify-rls: 8/8 passed` and exits 0.
 | Cross-tenant read                    | RLS policies (`0001_phase_2_rls_and_audit.sql`) + verified by `scripts/verify-rls`. |
 | Cross-tenant write                   | `WITH CHECK (tenant_id IN ...)` on every policy + verified by harness. |
 | Silent tenant pick across memberships| `resolveTenantContext` errors with `multiple_memberships` until the caller passes an explicit `preferredTenantId`. |
+| Stale tenant pin resolving to the wrong tenant | A supplied `preferredTenantId` is validated against active memberships on every path; a mismatch errors with `preferred_tenant_unavailable` rather than substituting the user's sole membership. |
 | `work_order_events` tamper           | RLS hides foreign rows; trigger raises even when RLS is bypassed. |
 | Stale session                        | `middleware.ts` calls `supabase.auth.getUser()` on every request, which rotates an expiring access token via `@supabase/ssr`'s cookie bridge. |
 | First-login bootstrap                | The `no_user_row` branch in the resolver communicates the missing `public.users` row explicitly instead of silently passing as unauthenticated. |

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "turbo": "^2.3.3",
-    "typescript": "^5.6.3"
+    "typescript": "^5.6.3",
+    "vitest": "^4.1.10"
   }
 }

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -25,7 +25,13 @@ Own shared workspace package contracts for Worksie.
 ## Verification
 
 - Run the touched package's lint/build/typecheck script when available.
-- Root closeout still requires `pnpm lint` and `pnpm build`.
+- Vitest is the test runner. Tests live beside their source as `*.test.ts`
+  under `src/`, so `tsc --noEmit` and `eslint src` cover them too. Import
+  `describe` / `it` / `expect` explicitly rather than enabling globals.
+- `auth/` and `domain/` have suites. The rest have no `test` script and are
+  skipped by `turbo run test`; add one when a package gains real logic rather
+  than shipping a placeholder that always passes.
+- Root closeout requires `pnpm lint`, `pnpm build`, and `pnpm test`.
 
 ## Child DOX Index
 

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint src --max-warnings 0",
     "typecheck": "tsc --noEmit",
     "build": "tsc --noEmit",
+    "test": "vitest run",
     "clean": "rm -rf dist .turbo node_modules"
   },
   "dependencies": {
@@ -24,6 +25,7 @@
     "@types/node": "^20.17.6",
     "@worksie/config": "workspace:*",
     "eslint": "^8.57.1",
-    "typescript": "^5.6.3"
+    "typescript": "^5.6.3",
+    "vitest": "^4.1.10"
   }
 }

--- a/packages/auth/src/tenant.test.ts
+++ b/packages/auth/src/tenant.test.ts
@@ -176,16 +176,31 @@ describe("resolveTenantContext", () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) return;
-    expect(result.reason).toBe("multiple_memberships");
+    expect(result.reason).toBe("preferred_tenant_unavailable");
   });
 
-  it("ignores preferredTenantId when only one membership is active", async () => {
-    // Documents CURRENT behaviour, which is not obviously the desired one.
-    // The `active.length === 1` branch is taken before preferredTenantId is
-    // ever read, so a caller that explicitly asks for tenant-b is silently
-    // given tenant-a rather than being told the request was impossible.
-    // Left as-is deliberately: this PR establishes a test baseline and does
-    // not change behaviour. Change the test with the fix, not before it.
+  it("honours preferredTenantId when it matches the single active membership", async () => {
+    const result = await resolveTenantContext({
+      authUser: AUTH_USER,
+      user: APP_USER,
+      memberships: [membership({ id: "m-a", tenantId: "tenant-a" })],
+      loadTenant,
+      preferredTenantId: "tenant-a"
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.membership.id).toBe("m-a");
+    expect(result.tenant).toEqual(TENANT_A);
+  });
+
+  it("fails rather than substituting the sole active membership for a mismatched preferredTenantId", async () => {
+    // The guarantee is "you get the tenant you asked for, or an error",
+    // and it must not depend on how many memberships the user happens to
+    // have. A stale tenant pin (URL segment, cookie) after a membership
+    // move would otherwise land the caller in tenant-a while their pin
+    // still says tenant-b — the silent wrong-tenant default that Hard
+    // Rule #1 exists to prevent.
     const result = await resolveTenantContext({
       authUser: AUTH_USER,
       user: APP_USER,
@@ -194,9 +209,54 @@ describe("resolveTenantContext", () => {
       preferredTenantId: "tenant-b"
     });
 
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(result.tenant.id).toBe("tenant-a");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("preferred_tenant_unavailable");
+  });
+
+  it("reports the same reason for a mismatched pick regardless of membership count", async () => {
+    // Guards the ordering fix directly: one cause, one reason. Before the
+    // fix these two shapes diverged (error vs. silent success).
+    const one = await resolveTenantContext({
+      authUser: AUTH_USER,
+      user: APP_USER,
+      memberships: [membership({ id: "m-a", tenantId: "tenant-a" })],
+      loadTenant,
+      preferredTenantId: "tenant-zzz"
+    });
+    const many = await resolveTenantContext({
+      authUser: AUTH_USER,
+      user: APP_USER,
+      memberships: [
+        membership({ id: "m-a", tenantId: "tenant-a" }),
+        membership({ id: "m-b", tenantId: "tenant-b" })
+      ],
+      loadTenant,
+      preferredTenantId: "tenant-zzz"
+    });
+
+    expect(one.ok).toBe(false);
+    expect(many.ok).toBe(false);
+    if (one.ok || many.ok) return;
+    expect(one.reason).toBe("preferred_tenant_unavailable");
+    expect(many.reason).toBe(one.reason);
+  });
+
+  it("does not resolve a preferred tenant the user is only inactively a member of", async () => {
+    const result = await resolveTenantContext({
+      authUser: AUTH_USER,
+      user: APP_USER,
+      memberships: [
+        membership({ id: "m-a", tenantId: "tenant-a" }),
+        membership({ id: "m-b", tenantId: "tenant-b", status: "suspended" })
+      ],
+      loadTenant,
+      preferredTenantId: "tenant-b"
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("preferred_tenant_unavailable");
   });
 
   it("collapses an unreadable tenant row into no_active_membership", async () => {
@@ -249,7 +309,8 @@ describe("describeTenantContextError", () => {
     "no_user_row",
     "no_membership",
     "no_active_membership",
-    "multiple_memberships"
+    "multiple_memberships",
+    "preferred_tenant_unavailable"
   ];
 
   it.each(reasons)("returns operator-facing copy for %s", (reason) => {

--- a/packages/auth/src/tenant.test.ts
+++ b/packages/auth/src/tenant.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  describeTenantContextError,
+  resolveTenantContext,
+  type AppUser,
+  type AuthUser,
+  type Membership,
+  type Tenant,
+  type TenantContextErrorReason
+} from "./tenant";
+
+const AUTH_USER: AuthUser = {
+  authUserId: "auth-1",
+  email: "operator@example.com"
+};
+
+const APP_USER: AppUser = {
+  id: "user-1",
+  authUserId: "auth-1",
+  email: "operator@example.com",
+  displayName: "Operator",
+  phone: null
+};
+
+const TENANT_A: Tenant = { id: "tenant-a", name: "Tenant A", timezone: "UTC" };
+const TENANT_B: Tenant = { id: "tenant-b", name: "Tenant B", timezone: "UTC" };
+
+const TENANTS: Record<string, Tenant> = {
+  "tenant-a": TENANT_A,
+  "tenant-b": TENANT_B
+};
+
+function membership(overrides: Partial<Membership> = {}): Membership {
+  return {
+    id: "membership-1",
+    tenantId: "tenant-a",
+    userId: "user-1",
+    role: "operator",
+    status: "active",
+    ...overrides
+  };
+}
+
+const loadTenant = (tenantId: string): Tenant | null =>
+  TENANTS[tenantId] ?? null;
+
+describe("resolveTenantContext", () => {
+  it("fails unauthenticated when there is no auth user", async () => {
+    const result = await resolveTenantContext({
+      authUser: null,
+      user: APP_USER,
+      memberships: [membership()],
+      loadTenant
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("unauthenticated");
+    // A failure must not leak identity it could not establish.
+    expect(result.authUser).toBeNull();
+    expect(result.user).toBeNull();
+    expect(result.memberships).toEqual([]);
+  });
+
+  it("fails no_user_row when authenticated but no public.users row exists", async () => {
+    const result = await resolveTenantContext({
+      authUser: AUTH_USER,
+      user: null,
+      memberships: [membership()],
+      loadTenant
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("no_user_row");
+    expect(result.authUser).toEqual(AUTH_USER);
+    expect(result.user).toBeNull();
+  });
+
+  it("fails no_membership when the user has none", async () => {
+    const result = await resolveTenantContext({
+      authUser: AUTH_USER,
+      user: APP_USER,
+      memberships: [],
+      loadTenant
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("no_membership");
+  });
+
+  it("fails no_active_membership when every membership is inactive", async () => {
+    const memberships = [
+      membership({ id: "m-invited", status: "invited" }),
+      membership({ id: "m-suspended", status: "suspended" })
+    ];
+
+    const result = await resolveTenantContext({
+      authUser: AUTH_USER,
+      user: APP_USER,
+      memberships,
+      loadTenant
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("no_active_membership");
+    // The caller needs the memberships back to render a useful message.
+    expect(result.memberships).toEqual(memberships);
+  });
+
+  it("resolves when exactly one membership is active", async () => {
+    const result = await resolveTenantContext({
+      authUser: AUTH_USER,
+      user: APP_USER,
+      memberships: [
+        membership({ id: "m-suspended", status: "suspended" }),
+        membership({ id: "m-active" })
+      ],
+      loadTenant
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.membership.id).toBe("m-active");
+    expect(result.tenant).toEqual(TENANT_A);
+  });
+
+  it("refuses to guess between multiple active memberships", async () => {
+    const result = await resolveTenantContext({
+      authUser: AUTH_USER,
+      user: APP_USER,
+      memberships: [
+        membership({ id: "m-a", tenantId: "tenant-a" }),
+        membership({ id: "m-b", tenantId: "tenant-b" })
+      ],
+      loadTenant
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("multiple_memberships");
+  });
+
+  it("honours preferredTenantId when it matches an active membership", async () => {
+    const result = await resolveTenantContext({
+      authUser: AUTH_USER,
+      user: APP_USER,
+      memberships: [
+        membership({ id: "m-a", tenantId: "tenant-a" }),
+        membership({ id: "m-b", tenantId: "tenant-b" })
+      ],
+      loadTenant,
+      preferredTenantId: "tenant-b"
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.membership.id).toBe("m-b");
+    expect(result.tenant).toEqual(TENANT_B);
+  });
+
+  it("does not fall back to another tenant when preferredTenantId matches nothing", async () => {
+    const result = await resolveTenantContext({
+      authUser: AUTH_USER,
+      user: APP_USER,
+      memberships: [
+        membership({ id: "m-a", tenantId: "tenant-a" }),
+        membership({ id: "m-b", tenantId: "tenant-b" })
+      ],
+      loadTenant,
+      preferredTenantId: "tenant-zzz"
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("multiple_memberships");
+  });
+
+  it("ignores preferredTenantId when only one membership is active", async () => {
+    // Documents CURRENT behaviour, which is not obviously the desired one.
+    // The `active.length === 1` branch is taken before preferredTenantId is
+    // ever read, so a caller that explicitly asks for tenant-b is silently
+    // given tenant-a rather than being told the request was impossible.
+    // Left as-is deliberately: this PR establishes a test baseline and does
+    // not change behaviour. Change the test with the fix, not before it.
+    const result = await resolveTenantContext({
+      authUser: AUTH_USER,
+      user: APP_USER,
+      memberships: [membership({ id: "m-a", tenantId: "tenant-a" })],
+      loadTenant,
+      preferredTenantId: "tenant-b"
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.tenant.id).toBe("tenant-a");
+  });
+
+  it("collapses an unreadable tenant row into no_active_membership", async () => {
+    // RLS hid the row or it was deleted between checks. The resolver
+    // deliberately does not distinguish this from "no access" so callers
+    // cannot probe for tenant existence.
+    const result = await resolveTenantContext({
+      authUser: AUTH_USER,
+      user: APP_USER,
+      memberships: [membership({ tenantId: "tenant-gone" })],
+      loadTenant
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("no_active_membership");
+  });
+
+  it("accepts an async loadTenant", async () => {
+    const asyncLoad = vi.fn(async (id: string) => TENANTS[id] ?? null);
+
+    const result = await resolveTenantContext({
+      authUser: AUTH_USER,
+      user: APP_USER,
+      memberships: [membership()],
+      loadTenant: asyncLoad
+    });
+
+    expect(result.ok).toBe(true);
+    expect(asyncLoad).toHaveBeenCalledWith("tenant-a");
+  });
+
+  it("does not load a tenant when resolution fails earlier", async () => {
+    const spy = vi.fn(loadTenant);
+
+    await resolveTenantContext({
+      authUser: AUTH_USER,
+      user: APP_USER,
+      memberships: [],
+      loadTenant: spy
+    });
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+describe("describeTenantContextError", () => {
+  const reasons: readonly TenantContextErrorReason[] = [
+    "unauthenticated",
+    "no_user_row",
+    "no_membership",
+    "no_active_membership",
+    "multiple_memberships"
+  ];
+
+  it.each(reasons)("returns operator-facing copy for %s", (reason) => {
+    const message = describeTenantContextError(reason);
+    expect(message.length).toBeGreaterThan(0);
+    // Operator-facing copy, so it must not echo the internal enum name.
+    expect(message).not.toContain(reason);
+  });
+
+  it("gives every reason a distinct message", () => {
+    const messages = reasons.map(describeTenantContextError);
+    expect(new Set(messages).size).toBe(reasons.length);
+  });
+});

--- a/packages/auth/src/tenant.ts
+++ b/packages/auth/src/tenant.ts
@@ -12,10 +12,19 @@
 //   - `no_active_membership`→ memberships exist but none are `active`
 //   - `multiple_memberships`→ more than one active membership and the
 //                             caller did not specify a tenant
+//   - `preferred_tenant_unavailable`
+//                           → the caller named a tenant and the user has
+//                             no active membership in it
 //
 // The "multiple_memberships" case is intentionally surfaced as an error
 // rather than picking one. The product needs a deliberate tenant switcher
 // before we silently default someone into the wrong tenant.
+//
+// `preferredTenantId` is a constraint, not a hint. It is validated on
+// every path, including the single-membership one, so the guarantee
+// "you get the tenant you asked for, or an error" never depends on how
+// many memberships the user happens to have. Callers that genuinely mean
+// "any tenant will do" express that by omitting the field.
 
 import type {
   MembershipRole,
@@ -54,7 +63,8 @@ export type TenantContextErrorReason =
   | "no_user_row"
   | "no_membership"
   | "no_active_membership"
-  | "multiple_memberships";
+  | "multiple_memberships"
+  | "preferred_tenant_unavailable";
 
 export type TenantContextResult =
   | {
@@ -81,10 +91,10 @@ export type TenantContextInputs = {
   readonly loadTenant: (
     tenantId: string
   ) => Tenant | null | Promise<Tenant | null>;
-  // Optional caller-supplied tenant pick. When the user has multiple
-  // active memberships the caller may pass the chosen tenant id; if it
-  // matches an active membership we resolve to that one instead of
-  // erroring with `multiple_memberships`.
+  // Optional caller-supplied tenant pick. When supplied it constrains
+  // the result: we resolve to that tenant's active membership, or fail
+  // with `preferred_tenant_unavailable`. We never fall back to a
+  // different tenant. Omit it to mean "any active membership will do".
   readonly preferredTenantId?: string;
 };
 
@@ -108,15 +118,18 @@ export async function resolveTenantContext(
     return failure("no_active_membership", authUser, user, memberships);
   }
 
+  // Order matters: the caller's pick is a filter on the candidate set,
+  // not a tiebreaker applied only when the set is ambiguous. Checking it
+  // first is what makes the contract independent of `active.length`.
   let chosen: Membership;
-  if (active.length === 1) {
-    chosen = active[0]!;
-  } else if (preferredTenantId) {
+  if (preferredTenantId) {
     const match = active.find((m) => m.tenantId === preferredTenantId);
     if (!match) {
-      return failure("multiple_memberships", authUser, user, memberships);
+      return failure("preferred_tenant_unavailable", authUser, user, memberships);
     }
     chosen = match;
+  } else if (active.length === 1) {
+    chosen = active[0]!;
   } else {
     return failure("multiple_memberships", authUser, user, memberships);
   }
@@ -162,5 +175,7 @@ export function describeTenantContextError(
       return "Signed in, but no active tenant membership.";
     case "multiple_memberships":
       return "Signed in with multiple active memberships — tenant must be selected explicitly.";
+    case "preferred_tenant_unavailable":
+      return "Signed in, but the requested tenant is not available to this account.";
   }
 }

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -12,12 +12,13 @@
     "lint": "eslint src --max-warnings 0",
     "typecheck": "tsc --noEmit",
     "build": "tsc --noEmit",
-    "test": "echo 'Phase 1: no tests yet'",
+    "test": "vitest run",
     "clean": "rm -rf dist .turbo node_modules"
   },
   "devDependencies": {
     "@worksie/config": "workspace:*",
     "eslint": "^8.57.1",
-    "typescript": "^5.6.3"
+    "typescript": "^5.6.3",
+    "vitest": "^4.1.10"
   }
 }

--- a/packages/domain/src/index.test.ts
+++ b/packages/domain/src/index.test.ts
@@ -1,0 +1,121 @@
+// These arrays are the source of truth for the PostgreSQL enum types
+// (see packages/db/src/schema/enums.ts). A change here becomes a Drizzle diff
+// and then a migration, so the invariants below guard the mirror contract:
+// duplicates or a reordering would produce SQL that is hard to reverse once
+// applied.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  ARTIFACT_PROCESSING_STATUSES,
+  CONTRACTOR_DOCUMENT_STATUSES,
+  ENTITY_NAMES,
+  MEMBERSHIP_ROLES,
+  MEMBERSHIP_STATUSES,
+  PAYOUT_PERIOD_STATUSES,
+  PAYOUT_RULE_MODES,
+  PROOF_OF_WORK_KINDS,
+  SYNC_CLASSES,
+  TERMINAL_WORK_ORDER_STATES,
+  WORK_ORDER_EVENT_SOURCES,
+  WORK_ORDER_STATES
+} from "./index";
+
+const ALL_ENUMS = {
+  ENTITY_NAMES,
+  WORK_ORDER_STATES,
+  TERMINAL_WORK_ORDER_STATES,
+  WORK_ORDER_EVENT_SOURCES,
+  MEMBERSHIP_ROLES,
+  MEMBERSHIP_STATUSES,
+  CONTRACTOR_DOCUMENT_STATUSES,
+  PAYOUT_RULE_MODES,
+  PAYOUT_PERIOD_STATUSES,
+  PROOF_OF_WORK_KINDS,
+  ARTIFACT_PROCESSING_STATUSES,
+  SYNC_CLASSES
+} as const;
+
+describe("domain enum hygiene", () => {
+  it.each(Object.entries(ALL_ENUMS))("%s has no duplicates", (_name, values) => {
+    expect(new Set(values).size).toBe(values.length);
+  });
+
+  it.each(Object.entries(ALL_ENUMS))("%s is non-empty", (_name, values) => {
+    expect(values.length).toBeGreaterThan(0);
+  });
+
+  // Only these arrays are mirrored into PostgreSQL enum types by
+  // packages/db/src/schema/enums.ts. ENTITY_NAMES is PascalCase by design and
+  // SYNC_CLASSES is a docs-facing label set; neither reaches SQL.
+  const PG_MIRRORED = [
+    WORK_ORDER_STATES,
+    WORK_ORDER_EVENT_SOURCES,
+    MEMBERSHIP_ROLES,
+    MEMBERSHIP_STATUSES,
+    CONTRACTOR_DOCUMENT_STATUSES,
+    PAYOUT_RULE_MODES,
+    PAYOUT_PERIOD_STATUSES,
+    PROOF_OF_WORK_KINDS,
+    ARTIFACT_PROCESSING_STATUSES
+  ] as const;
+
+  it("uses snake_case for every value that becomes a PostgreSQL enum label", () => {
+    for (const values of PG_MIRRORED) {
+      for (const value of values) {
+        expect(value).toMatch(/^[a-z][a-z0-9_]*$/);
+      }
+    }
+  });
+});
+
+describe("work order lifecycle", () => {
+  it("declares 21 canonical entities", () => {
+    // Matches docs/DOMAIN_MODEL.md and the 21 tables in packages/db.
+    expect(ENTITY_NAMES).toHaveLength(21);
+  });
+
+  it("treats every terminal state as a real work order state", () => {
+    for (const state of TERMINAL_WORK_ORDER_STATES) {
+      expect(WORK_ORDER_STATES).toContain(state);
+    }
+  });
+
+  it("keeps draft as the first state and leaves it non-terminal", () => {
+    expect(WORK_ORDER_STATES[0]).toBe("draft");
+    expect(TERMINAL_WORK_ORDER_STATES).not.toContain("draft");
+  });
+
+  it("marks paid_out, cancelled and voided terminal", () => {
+    expect([...TERMINAL_WORK_ORDER_STATES].sort()).toEqual([
+      "cancelled",
+      "paid_out",
+      "voided"
+    ]);
+  });
+});
+
+describe("proof of work", () => {
+  it("supports audio capture", () => {
+    // Added in Phase 3.5. Removing it would need an enum migration, so this
+    // guards against an accidental revert of the domain array.
+    expect(PROOF_OF_WORK_KINDS).toContain("audio");
+  });
+
+  it("orders upload states from pending through to a terminal outcome", () => {
+    expect(ARTIFACT_PROCESSING_STATUSES[0]).toBe("pending");
+    expect(ARTIFACT_PROCESSING_STATUSES).toContain("stored");
+    expect(ARTIFACT_PROCESSING_STATUSES).toContain("failed");
+  });
+});
+
+describe("sync classes", () => {
+  it("declares exactly the four classes in OFFLINE_FIRST_ARCHITECTURE.md", () => {
+    expect(SYNC_CLASSES).toEqual([
+      "A_reference",
+      "B_assigned",
+      "C_append_only",
+      "D_server_only"
+    ]);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@20.19.41)(vite@8.2.0(@types/node@20.19.41)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.47.1)(tsx@4.22.1))
 
   apps/mobile:
     dependencies:
@@ -152,6 +155,9 @@ importers:
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@20.19.41)(vite@8.2.0(@types/node@20.19.41)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.47.1)(tsx@4.22.1))
 
   packages/config:
     devDependencies:
@@ -201,6 +207,9 @@ importers:
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@20.19.41)(vite@8.2.0(@types/node@20.19.41)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.47.1)(tsx@4.22.1))
 
   packages/types:
     devDependencies:
@@ -1001,19 +1010,28 @@ packages:
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
+  '@emnapi/core@2.0.0-alpha.3':
+    resolution: {integrity: sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==}
+
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/runtime@2.0.0-alpha.3':
+    resolution: {integrity: sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==}
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
+  '@emnapi/wasi-threads@2.0.1':
+    resolution: {integrity: sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==}
+
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild/aix-ppc64@0.19.12':
     resolution: {integrity: sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==}
@@ -1461,7 +1479,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
 
   '@expo/cli@0.22.28':
     resolution: {integrity: sha512-lvt72KNitGuixYD2l3SZmRKVu2G4zJpmg5V7WfUBNpmUU5oODBw/6qmiJ6kSLAlfDozscUk+BBGknBBzxUrwrA==}
@@ -1729,6 +1747,13 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
+  '@napi-rs/wasm-runtime@1.2.2':
+    resolution: {integrity: sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.3
+      '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.3
+
   '@next/env@15.0.3':
     resolution: {integrity: sha512-t9Xy32pjNOvVn2AS+Utt6VmyrshbpfUMhIjFO60gI58deSo/KgLOp31XZ4O+kY/Is8WAGYwA5gR7kOb1eORDBA==}
 
@@ -1802,6 +1827,9 @@ packages:
   '@npmcli/fs@3.1.1':
     resolution: {integrity: sha512-q9CRWjpHCMIh5sVyefoD1cA7PkvILqCZsnSOEUUivORLjxCO/Irmue2DprETiNgEqktDBZaM1Bi+jrarx1XdCg==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  '@oxc-project/types@0.142.0':
+    resolution: {integrity: sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -1956,6 +1984,97 @@ packages:
   '@react-navigation/routers@7.5.5':
     resolution: {integrity: sha512-9/hhMte12Kgu+pMnLfA4EWJ0OQmIEAMVMX06FPH2yGkEQSQ3JhhCN/GkcRikzQhtEi97VYYQA15umptBUShcOQ==}
 
+  '@rolldown/binding-android-arm64@1.2.1':
+    resolution: {integrity: sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.2.1':
+    resolution: {integrity: sha512-fMsTOnN0OjFm3CyppWPitKnc8UlliVARUULW6cfU6AIqjdtgmSFWSk9vecHzZduv/yMWIHDlRhM1e8Iff9uAfA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.2.1':
+    resolution: {integrity: sha512-1wjKdz/XLGKHaTNHjQveQ/B23TKx4ItAqm1JbyVuvNPc4Ze0Fb48s49TAd/2zcplPl8okE/UbTgmlVfwT7eFeQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.2.1':
+    resolution: {integrity: sha512-Fa0jHR07E7YBN4vOEsbVf2briYNsuOowfLJaXULZM0ldMlaCaj2LJgLMbMe4iacRyZmvR8efFhgR9wKuGclQUg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.1':
+    resolution: {integrity: sha512-pzkgu1SSHGgRRyRZ4fbmSgmajbVt+epaLP99NDjFft69v/ypfTi6swBMiVdh2EkQ0OSnHE1lZDM7DRGkyAzUpA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.1':
+    resolution: {integrity: sha512-QI5SEDY8cbiYWHx0VO4vIc3UlS6a32vXHjU8Qy/17adEmZIPuByJg13UEvo9c/UCiUkdcVWY83C+b+JrwnNyUg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.2.1':
+    resolution: {integrity: sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.1':
+    resolution: {integrity: sha512-2x+WhXTGl9yJYPbltW/BSEPTVz9OIWQyER4N+gJEDWkkn904eRcBzELqh/Hf7K0w/ubGbKNMv0ZC+94QK/IFEg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.1':
+    resolution: {integrity: sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.2.1':
+    resolution: {integrity: sha512-/Orga1fZYkLc/56jBICcHrKchl8Z2UKdDSr3LG9ToWO1lQ6a4Livk9Xz+9WN91zsz5QR3XQz2NNoSDEvP6qadw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.2.1':
+    resolution: {integrity: sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.2.1':
+    resolution: {integrity: sha512-M6AdXIXw3s+/8XpKMzdGDEXGS1S7kwUsy+rcTIUIOx5Ge4nXKCtAFHFV9YKkXvGcC5WMoTjAteLzlsQROVI0Yw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.2.1':
+    resolution: {integrity: sha512-/TX0SoRGojHzSAHpfVBbavRVSazg5U3h3Y3VXfcc0cdugq6kxdqw8LPGFiPr+/7gE/60zRcsOY2Vi9b9eT0jww==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.1':
+    resolution: {integrity: sha512-EvRrivJieyHG+AO9lleZWgq+g0+S7oV2C51yuqlcyU/R9net+sI4Pj0F+lUoP2bEr6TWX3SqFaaS0SzfLxSzkw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.2.1':
+    resolution: {integrity: sha512-Z4eCmn5QJ/5+azF9knpLWKfVd9aidn0mAe9TpJgvBLId9Ax3t0+JVxBmT25Bv7NBbVW1TZyKjQjQReouMeH5UQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -1973,6 +2092,9 @@ packages:
 
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@supabase/auth-js@2.105.4':
     resolution: {integrity: sha512-Ejfa37M5xoIwoxVebxRahnwubPo8g22qkXQ4p50+N9MIvU9UZoN+A8dwVPtczzGf8oV/YXN80ZPxK4aWXuSN/A==}
@@ -2045,6 +2167,9 @@ packages:
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -2057,8 +2182,17 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
@@ -2269,6 +2403,35 @@ packages:
     peerDependencies:
       '@urql/core': ^5.0.0
 
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
   '@xmldom/xmldom@0.7.13':
     resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
     engines: {node: '>=10.0.0'}
@@ -2412,6 +2575,10 @@ packages:
 
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
@@ -2658,6 +2825,10 @@ packages:
 
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -3100,6 +3271,9 @@ packages:
     resolution: {integrity: sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -3285,6 +3459,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -3304,6 +3481,10 @@ packages:
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   expo-asset@11.0.5:
     resolution: {integrity: sha512-TL60LmMBGVzs3NQcO8ylWqBumMh4sx0lmeJsn7+9C88fylGDhyyVnKZ1PyTXo9CVDBkndutZx2JUEQWM9BaiXw==}
@@ -4077,8 +4258,20 @@ packages:
   lighthouse-logger@1.4.2:
     resolution: {integrity: sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==}
 
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
   lightningcss-darwin-arm64@1.27.0:
     resolution: {integrity: sha512-Gl/lqIXY+d+ySmMbgDf0pgaWSqrWYxVHoc88q+Vhf2YNzZ8DwoRzGt5NZDVqqIW5ScpSnmmjcgXP87Dn2ylSSQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
@@ -4089,8 +4282,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
   lightningcss-freebsd-x64@1.27.0:
     resolution: {integrity: sha512-n1sEf85fePoU2aDN2PzYjoI8gbBqnmLGEhKq7q0DKLj0UTVmOTwDC7PtLcy/zFxzASTSBlVQYJUhwIStQMIpRA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
@@ -4101,8 +4306,20 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
   lightningcss-linux-arm64-gnu@1.27.0:
     resolution: {integrity: sha512-cPsxo1QEWq2sfKkSq2Bq5feQDHdUEwgtA9KaB27J5AX22+l4l0ptgjMZZtYtUnteBofjee+0oW1wQ1guv04a7A==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -4113,8 +4330,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
   lightningcss-linux-x64-gnu@1.27.0:
     resolution: {integrity: sha512-Dk/jovSI7qqhJDiUibvaikNKI2x6kWPN79AQiD/E/KeQWMjdGe9kw51RAgoWFDi0coP4jinaH14Nrt/J8z3U4A==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
@@ -4125,8 +4354,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
   lightningcss-win32-arm64-msvc@1.27.0:
     resolution: {integrity: sha512-/wXegPS1hnhkeG4OXQKEMQeJd48RDC3qdh+OA8pCuOPCyvnm/yEayrJdJVqzBsqpy1aJklRCVxscpFur80o6iQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
@@ -4137,8 +4378,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
   lightningcss@1.27.0:
     resolution: {integrity: sha512-8f7aNmS1+etYSLHht0fQApPc2kNO8qGRutifN5rVIc6Xo6ABsEbqOr758UwI7ALVbTt4x1fllKt0PYgzD9S3yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lightningcss@1.33.0:
+    resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
     engines: {node: '>= 12.0.0'}
 
   lilconfig@3.1.3:
@@ -4182,6 +4433,9 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   make-dir@2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
@@ -4370,6 +4624,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   napi-postinstall@0.3.4:
     resolution: {integrity: sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
@@ -4503,6 +4762,10 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
   on-finished@2.3.0:
     resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
     engines: {node: '>= 0.8'}
@@ -4628,6 +4891,9 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -4641,6 +4907,10 @@ packages:
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
   pify@2.3.0:
@@ -4724,6 +4994,10 @@ packages:
 
   postcss@8.5.14:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.25:
+    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres@3.4.9:
@@ -4992,6 +5266,11 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
+  rolldown@1.2.1:
+    resolution: {integrity: sha512-4FKJhg8d3OiyQOA6Q1Q0hoFFpW9/OoX+VsHzpECsdsIZoOArrAK90gl59YK/Z+gnDel45bgJZK03ozH/9bCqEw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -5133,6 +5412,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -5190,6 +5472,9 @@ packages:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stackframe@1.3.4:
     resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
 
@@ -5204,6 +5489,9 @@ packages:
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -5381,9 +5669,24 @@ packages:
   throat@5.0.0:
     resolution: {integrity: sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
 
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
@@ -5574,6 +5877,90 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  vite@8.2.0:
+    resolution: {integrity: sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.4.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vlq@1.0.1:
     resolution: {integrity: sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==}
 
@@ -5630,6 +6017,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wonka@6.3.6:
@@ -6666,12 +7058,28 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/core@2.0.0-alpha.3':
+    dependencies:
+      '@emnapi/wasi-threads': 2.0.1
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.10.0':
     dependencies:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/runtime@2.0.0-alpha.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@2.0.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -7406,6 +7814,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
+  '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)':
+    dependencies:
+      '@emnapi/core': 2.0.0-alpha.3
+      '@emnapi/runtime': 2.0.0-alpha.3
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@next/env@15.0.3': {}
 
   '@next/eslint-plugin-next@15.0.3':
@@ -7453,6 +7868,8 @@ snapshots:
   '@npmcli/fs@3.1.1':
     dependencies:
       semver: 7.8.0
+
+  '@oxc-project/types@0.142.0': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -7768,6 +8185,57 @@ snapshots:
     dependencies:
       nanoid: 3.3.12
 
+  '@rolldown/binding-android-arm64@1.2.1':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.2.1':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.2.1':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.2.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.2.1':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.1':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.1':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.2.1':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.2.1':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.2.1':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.2.1':
+    dependencies:
+      '@emnapi/core': 2.0.0-alpha.3
+      '@emnapi/runtime': 2.0.0-alpha.3
+      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.1':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.2.1':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.16.1': {}
@@ -7786,6 +8254,8 @@ snapshots:
   '@sinonjs/fake-timers@10.3.0':
     dependencies:
       '@sinonjs/commons': 3.0.1
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@supabase/auth-js@2.105.4':
     dependencies:
@@ -7854,6 +8324,11 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.29.3
@@ -7875,7 +8350,16 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/cookie@0.6.0': {}
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/graceful-fs@4.1.9':
     dependencies:
@@ -8086,6 +8570,47 @@ snapshots:
       '@urql/core': 5.2.0
       wonka: 6.3.6
 
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.10(vite@8.2.0(@types/node@20.19.41)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.47.1)(tsx@4.22.1))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.2.0(@types/node@20.19.41)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.47.1)(tsx@4.22.1)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
+
   '@xmldom/xmldom@0.7.13': {}
 
   '@xmldom/xmldom@0.9.10': {}
@@ -8244,6 +8769,8 @@ snapshots:
       is-array-buffer: 3.0.5
 
   asap@2.0.6: {}
+
+  assertion-error@2.0.1: {}
 
   ast-types-flow@0.0.8: {}
 
@@ -8534,6 +9061,8 @@ snapshots:
 
   caniuse-lite@1.0.30001793: {}
 
+  chai@6.2.2: {}
+
   chalk@2.4.2:
     dependencies:
       ansi-styles: 3.2.1
@@ -8803,8 +9332,7 @@ snapshots:
 
   detect-libc@1.0.3: {}
 
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
 
   didyoumean@1.2.2: {}
 
@@ -8957,6 +9485,8 @@ snapshots:
       iterator.prototype: 1.1.5
       math-intrinsics: 1.1.0
 
+  es-module-lexer@2.3.1: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -9080,7 +9610,7 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 8.59.3(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/parser': 8.59.3(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
       eslint-plugin-expo: 0.1.4(eslint@8.57.1)(typescript@5.9.3)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
@@ -9099,7 +9629,7 @@ snapshots:
       '@typescript-eslint/parser': 8.59.3(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
@@ -9119,7 +9649,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -9134,14 +9664,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.59.3(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -9165,7 +9695,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.3(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -9302,6 +9832,10 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
@@ -9329,6 +9863,8 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
+
+  expect-type@1.4.0: {}
 
   expo-asset@11.0.5(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.5(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.3(@babel/core@7.29.0)(@babel/preset-env@7.29.5(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.3(@babel/core@7.29.0)(@babel/preset-env@7.29.5(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.29.0)(@babel/preset-env@7.29.5(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -9519,6 +10055,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
 
   fetch-retry@4.1.1: {}
 
@@ -10210,34 +10750,67 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  lightningcss-android-arm64@1.33.0:
+    optional: true
+
   lightningcss-darwin-arm64@1.27.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.33.0:
     optional: true
 
   lightningcss-darwin-x64@1.27.0:
     optional: true
 
+  lightningcss-darwin-x64@1.33.0:
+    optional: true
+
   lightningcss-freebsd-x64@1.27.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.33.0:
     optional: true
 
   lightningcss-linux-arm-gnueabihf@1.27.0:
     optional: true
 
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    optional: true
+
   lightningcss-linux-arm64-gnu@1.27.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.33.0:
     optional: true
 
   lightningcss-linux-arm64-musl@1.27.0:
     optional: true
 
+  lightningcss-linux-arm64-musl@1.33.0:
+    optional: true
+
   lightningcss-linux-x64-gnu@1.27.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.33.0:
     optional: true
 
   lightningcss-linux-x64-musl@1.27.0:
     optional: true
 
+  lightningcss-linux-x64-musl@1.33.0:
+    optional: true
+
   lightningcss-win32-arm64-msvc@1.27.0:
     optional: true
 
+  lightningcss-win32-arm64-msvc@1.33.0:
+    optional: true
+
   lightningcss-win32-x64-msvc@1.27.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.33.0:
     optional: true
 
   lightningcss@1.27.0:
@@ -10254,6 +10827,22 @@ snapshots:
       lightningcss-linux-x64-musl: 1.27.0
       lightningcss-win32-arm64-msvc: 1.27.0
       lightningcss-win32-x64-msvc: 1.27.0
+
+  lightningcss@1.33.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
 
   lilconfig@3.1.3: {}
 
@@ -10291,6 +10880,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   make-dir@2.1.0:
     dependencies:
@@ -10571,6 +11164,8 @@ snapshots:
 
   nanoid@3.3.12: {}
 
+  nanoid@3.3.16: {}
+
   napi-postinstall@0.3.4: {}
 
   natural-compare@1.4.0: {}
@@ -10698,6 +11293,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  obug@2.1.4: {}
+
   on-finished@2.3.0:
     dependencies:
       ee-first: 1.1.1
@@ -10819,6 +11416,8 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pathe@2.0.3: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -10826,6 +11425,8 @@ snapshots:
   picomatch@3.0.2: {}
 
   picomatch@4.0.4: {}
+
+  picomatch@4.0.5: {}
 
   pify@2.3.0: {}
 
@@ -10894,6 +11495,12 @@ snapshots:
   postcss@8.5.14:
     dependencies:
       nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.25:
+    dependencies:
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -11222,6 +11829,27 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
+  rolldown@1.2.1:
+    dependencies:
+      '@oxc-project/types': 0.142.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.2.1
+      '@rolldown/binding-darwin-arm64': 1.2.1
+      '@rolldown/binding-darwin-x64': 1.2.1
+      '@rolldown/binding-freebsd-x64': 1.2.1
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.1
+      '@rolldown/binding-linux-arm64-gnu': 1.2.1
+      '@rolldown/binding-linux-arm64-musl': 1.2.1
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.1
+      '@rolldown/binding-linux-s390x-gnu': 1.2.1
+      '@rolldown/binding-linux-x64-gnu': 1.2.1
+      '@rolldown/binding-linux-x64-musl': 1.2.1
+      '@rolldown/binding-openharmony-arm64': 1.2.1
+      '@rolldown/binding-wasm32-wasi': 1.2.1
+      '@rolldown/binding-win32-arm64-msvc': 1.2.1
+      '@rolldown/binding-win32-x64-msvc': 1.2.1
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -11413,6 +12041,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -11458,6 +12088,8 @@ snapshots:
     dependencies:
       escape-string-regexp: 2.0.0
 
+  stackback@0.0.2: {}
+
   stackframe@1.3.4: {}
 
   stacktrace-parser@0.1.11:
@@ -11467,6 +12099,8 @@ snapshots:
   statuses@1.5.0: {}
 
   statuses@2.0.2: {}
+
+  std-env@4.2.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -11692,10 +12326,21 @@ snapshots:
 
   throat@5.0.0: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinyrainbow@3.1.1: {}
 
   tmpl@1.0.5: {}
 
@@ -11884,6 +12529,48 @@ snapshots:
 
   vary@1.1.2: {}
 
+  vite@8.2.0(@types/node@20.19.41)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.47.1)(tsx@4.22.1):
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.5
+      postcss: 8.5.25
+      rolldown: 1.2.1
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 20.19.41
+      esbuild: 0.28.0
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      terser: 5.47.1
+      tsx: 4.22.1
+
+  vitest@4.1.10(@types/node@20.19.41)(vite@8.2.0(@types/node@20.19.41)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.47.1)(tsx@4.22.1)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.2.0(@types/node@20.19.41)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.47.1)(tsx@4.22.1))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.1
+      vite: 8.2.0(@types/node@20.19.41)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.47.1)(tsx@4.22.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.41
+    transitivePeerDependencies:
+      - msw
+
   vlq@1.0.1: {}
 
   walker@1.0.8:
@@ -11963,6 +12650,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wonka@6.3.6: {}
 


### PR DESCRIPTION
Third of three. **Stacked on #41.** Outside the `LGA_MODEL.md` ontology→schema chain — this is tooling and correctness, not domain.

Three independent commits; review them separately.

## 1. `test:` Vitest baseline

The repo had **no test framework at all**. The only `test` script anywhere was `echo 'Phase 1: no tests yet'`, so CI's existing `turbo run test` step was green and asserted nothing — worse than no step, because it reads as coverage.

50 tests against the two packages with real logic. `packages/auth` covers every branch of `resolveTenantContext`'s error model. `packages/domain` guards the domain→pgEnum mirror contract, where a duplicate or reorder becomes SQL that is painful to reverse once applied.

**Verified the suite can actually fail.** Mutating `resolveTenantContext` to silently pick the first active membership produced 1 failed / 17 passed, naming the right test. Mutation reverted.

## 2. `fix(auth):` tenant-boundary fix — read this one closely

`resolveTenantContext` checked `active.length === 1` **before** it read `preferredTenantId`, so the single-membership branch was taken without the caller's pick ever being consulted. A caller asking for tenant B, for a user whose one active membership is in tenant A, silently received tenant A.

That contradicted the file's own header, which says the `multiple_memberships` error exists so we "don't silently default someone into the wrong tenant." The guarantee held for two-or-more memberships and quietly lapsed for one — the motivating case being a stale tenant pin in a URL or cookie after a membership move.

⚠️ **Behaviour change on an existing path.** Two-or-more active memberships with a non-matching `preferredTenantId` previously reported `multiple_memberships` and now reports the new `preferred_tenant_unavailable`. No caller in this repo switches on the reason — `me/page.tsx` renders it through `describeTenantContextError` and `lib/tenant/context.ts` is a pass-through — and `me/page.tsx` supplies no `preferredTenantId`, so no current application behaviour changes. Any future external consumer would need checking.

## 3. `docs(agents):` correct an unfollowable instruction

Root `AGENTS.md` told agents that "Vercel auto-deploys a preview for every PR" and to confirm the Vercel check before declaring a task done. Verified false: `vercel[bot]` last deployed 2025-10-16, and at least four PRs since — including one whose CI completed today at 17:16:15Z — produced zero deployments. An instruction that cannot be satisfied makes an agent either fabricate a preview URL or block forever.

## Merge readiness — GLOBAL_MERGE_CRITERIA §5

### A. Repository / branch
- [x] Repo `AudioJones-Dev/worksie`, clean tree before push
- [x] Source `claude/worksie-quality-baseline` @ `bb61d78e1bde2a96ed97e2c0f45bfde0aa532906`, target `claude/worksie-phase-3-5-schema` @ `e926b857…`
- [x] 3 commits ahead of base, 0 behind
- [x] **Divergence explained:** stacked; retargets to `main` as the stack merges

### B. Scope
- [x] 10 files, +1221 / −33. 714 insertions are `pnpm-lock.yaml` from adding Vitest
- [x] Every file maps to one of the three commits
- [x] **Contains an auth change** — disclosed above, not hidden. No billing, deployment, or permission change
- [x] Risk level **L4b** on merge; the auth commit is the escalation point under matrix §8

### C. Validation
- [x] `pnpm lint` 13/13
- [x] `pnpm build` 9/9
- [x] `pnpm test` 6/6 tasks — **54 tests** (32 domain + 22 auth), 0 failures
- [x] Dependency review: one addition, `vitest@4.1.10`, devDependency only, never a runtime dep
- ⚠️ **CI does NOT run on this PR while it is stacked.** `.github/workflows/ci.yml` triggers only on `pull_request: branches: [main]`; this PR targets a feature branch, so `lint / typecheck / build` will not appear until the parent merges and GitHub retargets this to `main`. Under GLOBAL_MERGE_CRITERIA §4 (PRODUCTION tier) absent CI is a **DO_NOT_MERGE** finding, so this PR is not merge-eligible until it retargets and CI goes green on the exact head. That constraint enforces the stack order rather than fighting it. Local equivalents of the same three commands are recorded above.

### D. Safety
- [x] Secret scan clean; only prose matches
- [x] No client or PII data
- [x] No destructive behaviour
- [x] No new external side effects. Vitest runs offline
- [x] Auth change **tightens** the tenant boundary rather than loosening it

### E. Review
- [x] Full diff reviewed; each of the three commits explained above
- [x] Regression risk: **the auth commit is the only real one** — see below
- [x] No unresolved blocking TODO/FIXME
- Rollback: `git revert` any of the three commits independently; they do not depend on each other. Blast radius **repo-only**

### Strongest reason not to merge

`vitest` is **not on `APPROVED_TOOLS.md`**, which is empty with `default: deny`. Matrix §10 permits an install when the package is in the manifest, on the registry, or explicitly approved this session; only the third applies here, via an approved plan naming Vitest. That is defensible but thin, and it is a governance gap rather than a technical one. `PROPOSED_AMENDMENT-2026-07-31.md` proposes registering it. **Merging this before that amendment ratifies leaves an unregistered dependency in the tree.**

On the auth change specifically: it is correct, but it is a behaviour change to the tenant boundary shipped in the same PR as test infrastructure and a docs fix. A reviewer wanting maximum care should ask for it to be split out and reviewed alone. It is bundled here because its tests depend on the Vitest commit; splitting means a fourth stacked PR.

---

**Decision:** RECOMMEND_MERGE (advisory only)
**Risk Level:** L4b on merge
**Human Approval Required:** YES — blocked on the same conditions as the rest of the stack, and this must not merge before the schema PR
**Audit:** `AUDIT-LOG/AUDIT-2026-07-31.md`

Opened as **draft**. No merge, no ready-for-review, no auto-merge requested or authorized.
